### PR TITLE
Issue #31, Accept leave application for next year after Oct. 1st

### DIFF
--- a/app/models/leave_time.rb
+++ b/app/models/leave_time.rb
@@ -11,13 +11,16 @@ class LeaveTime < ApplicationRecord
     where(year: year, user_id: user_id)
   }
 
-  scope :personal, ->(user_id, leave_type){
-    find_by(user_id: user_id, leave_type: leave_type)
+  scope :personal, ->(user_id, leave_type, year = Time.current.year){
+    find_by(user_id: user_id, leave_type: leave_type, year: year)
   }
 
   scope :get_employees_bonus, ->(){
     where("leave_type = ?", "bonus").order(user_id: :desc)
   }
+
+  validates :leave_type,
+            uniqueness: { scope: [:user_id, :year], message: '已存在該假別' }
 
   def init_quota
     return false if seniority < 1

--- a/config/initializers/working_time.rb
+++ b/config/initializers/working_time.rb
@@ -9,4 +9,3 @@ WorkingHours::Config.working_hours = {
 
 # Configure timezone (uses activesupport, defaults to UTC)
 WorkingHours::Config.time_zone = 'Taipei'
-

--- a/config/locales/meta_data.zh_TW.yml
+++ b/config/locales/meta_data.zh_TW.yml
@@ -34,14 +34,14 @@ zh-TW:
           attributes:
             leave_type:
               blank: "請選擇請假種類"
+              only_take_annual_leave_year_before: "只有特休假得以於前一年提前請假"
             description:
               blank: "請簡述原因"
             start_time:
               should_be_earlier: "開始時間必須早於結束時間"
             end_time:
               not_integer: "請假的最小單位是1小時"
-            status:
-              cannot_cancel_after_happened: "已核准之休假不得於發生後取消"
+              not_enough_leave_time: "剩餘休假時間不足"
 
   # navbar 選單標題
   nav:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,6 @@
-# 每年 1/1 00:05 init quota
-every "5 0 1 1 *" do
-  rake "leave_time:init"
+# 每年 10/1 00:05 初始化隔年休假額度
+every '5 0 1 10 *' do
+  rake "leave_time:init[Time.current.year + 1,'force']"
 end
 
 # 每日 00:10 檢查 fulltime employee 是否獲得 8hr 特休

--- a/spec/controllers/leave_applications_controller_spec.rb
+++ b/spec/controllers/leave_applications_controller_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 RSpec.describe LeaveApplicationsController, type: :controller do
   describe "#cancel" do
-    let(:leave_application) { FactoryGirl.create(:leave_application, :approved, :with_leave_time) }
+    let(:leave_application) { FactoryGirl.create(:leave_application, :approved, :annual, :with_leave_time) }
     let(:params) { { id: leave_application.id } }
     subject { post :cancel, params: params }
 
@@ -26,7 +26,7 @@ RSpec.describe LeaveApplicationsController, type: :controller do
 
     shared_examples "cancel owned leave_application" do
       context "canceling owned leave_application" do
-        let(:leave_application) { FactoryGirl.create(:leave_application, :approved, :with_leave_time, user: controller.current_user) }
+        let(:leave_application) { FactoryGirl.create(:leave_application, :approved, :annual, :with_leave_time, user: controller.current_user) }
 
         context "approved but already passed" do
           include_examples "cancel rejected"

--- a/spec/factories/leave_applicaiton.rb
+++ b/spec/factories/leave_applicaiton.rb
@@ -4,22 +4,22 @@ FactoryGirl.define do
     user
     leave_type  "personal"
     description { Faker::Lorem.characters(30) }
-    start_time  { 3.days.since.beginning_of_hour }
-    end_time    { 5.days.since.beginning_of_hour }
+    start_time  { 3.working.day.from_now.beginning_of_day + 9.hours + 30.minutes }
+    end_time    { 5.working.day.from_now.beginning_of_day + 18.hours + 30.minutes }
 
-    trait :sick_leave do
+    trait :sick do
       leave_type "sick"
     end
 
-    trait :personal_leave do
+    trait :personal do
       leave_type "personal"
     end
 
-    trait :bonus_leave do
+    trait :bonus do
       leave_type "bonus"
     end
 
-    trait :annual_leave do
+    trait :annual do
       leave_type "annual"
     end
 
@@ -33,9 +33,17 @@ FactoryGirl.define do
       end_time   { 1.days.since.beginning_of_hour }
     end
 
+    trait :next_year do
+      start_time { WorkingHours.next_working_time(1.year.since) }
+      end_time   { WorkingHours.next_working_time(1.year.since) + 9.hours }
+    end
+
     trait :with_leave_time do
       before(:create) do |la|
-        create(:leave_time, la.leave_type.to_sym, user: la.user)
+        create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
+      end
+      after(:stub) do |la|
+        create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
       end
     end
   end


### PR DESCRIPTION
## Issue #31, Accept leave application for next year after Oct. 1st
- Initialize LeaveTime quota on Oct, 1st each year
- Add validation for LeaveApplication to ensure employee can only submit
  application for next year's leave only when leave_type is :annual
- Add validation to check if there's still enough LeavTime remaining
  when creating LeaveApplication
- Add validation to make sure there's no duplicate LeaveTime entry