### PR TITLE
Issue #31, Add statistics for approved LeaveApplication by month

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'hirb-unicode'
+  gem 'rack-mini-profiler', '~> 0.10.1'
   gem 'capistrano', '~> 3.1'
   gem 'capistrano-rails', '~> 1.1'
   gem 'capistrano-upload-config'
@@ -68,6 +69,7 @@ group :test do
   gem 'shoulda-matchers'
   gem 'database_rewinder'
   gem 'timecop'
+  gem 'rails-controller-testing'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
     pg (0.19.0)
     puma (3.6.0)
     rack (2.0.1)
+    rack-mini-profiler (0.10.1)
+      rack (>= 1.2.0)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.0.1)
@@ -161,6 +163,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
@@ -280,7 +286,9 @@ DEPENDENCIES
   paranoia (~> 2.2)
   pg (~> 0.18)
   puma (~> 3.0)
+  rack-mini-profiler (~> 0.10.1)
   rails (>= 5.0.0.rc1, < 5.1)
+  rails-controller-testing
   rspec-rails
   sass-rails (~> 5.0)
   settingslogic

--- a/app/assets/javascripts/pages/backend/leave_applications.js
+++ b/app/assets/javascripts/pages/backend/leave_applications.js
@@ -15,4 +15,15 @@ document.addEventListener("turbolinks:load", function() {
     status = $leaveStatus.val();
     Turbolinks.visit("/backend/leave_applications?status=" + status + "&year=" + year );
   })
+
+  var $statistics_year  = $("select[id=year]")
+  var $statistics_month = $("select[id=month]")
+
+  $statistics_year.on('change', function() {
+    Turbolinks.visit("/backend/leave_applications/statistics?year=" + $statistics_year.val() + "&month=" + $statistics_month.val());
+  });
+
+  $statistics_month.on('change', function() {
+    Turbolinks.visit("/backend/leave_applications/statistics?year=" + $statistics_year.val() + "&month=" + $statistics_month.val());
+  });
 })

--- a/app/controllers/backend/leave_applications_controller.rb
+++ b/app/controllers/backend/leave_applications_controller.rb
@@ -22,6 +22,10 @@ class Backend::LeaveApplicationsController < Backend::BaseController
     end
   end
 
+  def statistics
+    @users = User.with_leave_application_statistics(specific_year, specific_month).all
+  end
+
   private
 
   def approve

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,4 +80,9 @@ module ApplicationHelper
   def specific_month
     params[:month] || Time.now.month
   end
+
+  def hours_to_humanize(hours)
+    return "-" if hours == 0
+    I18n.t("time.humanize_working_hour", days: hours.to_i/8, hours: hours%8, total: hours)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,17 @@ class User < ApplicationRecord
       .order(id: :desc)
   }
 
+  scope :with_leave_application_statistics, ->(year, month) {
+    joins(:leave_applications, :leave_times)
+    .includes(:leave_applications, :leave_times)
+    .merge(LeaveApplication.leave_within_range(
+      WorkingHours.advance_to_working_time(Time.new(year, month, 1)),
+      WorkingHours.return_to_working_time(Time.new(year, month, 1).end_of_month))
+      .approved
+    )
+    .merge(LeaveTime.where(year: year)).distinct
+  }
+
   def seniority(year = Time.now.year)
     if join_date.nil? or join_date.year > year
       0

--- a/app/views/backend/leave_applications/statistics.html.haml
+++ b/app/views/backend/leave_applications/statistics.html.haml
@@ -1,0 +1,42 @@
+%h2= t("captions.backend/leave_applications.statistics", year: specific_year, month: specific_month)
+%hr
+
+.year-mon-selector
+  .row
+    .col-md-6.col-sm-6.col-xs-12
+      .form-group
+        %label{:for=>"year"} Year
+        = select_tag "year",
+          options_for_select(2016 .. Time.now.year, specific_year),
+          class: "form-control"
+
+    .col-md-6.col-sm-6.col-xs-12
+      .form-group
+        %label{:for=>"month"} Month
+        = select_tag "month", options_for_select(1..12, specific_month),
+          class: "form-control"
+
+- if @users.present?
+  .table-responsive
+    %table.table.table-bordered.table-striped.table-hover
+      %thead
+        %tr.active
+          %th.name=  t_attribute(:name, User)
+          %th 別名
+          %th.hours.text-right= t("simple_form.options.leave_time.leave_type.annual")
+          %th.hours.text-right= t("simple_form.options.leave_time.leave_type.bonus")
+          %th.hours.text-right= t("simple_form.options.leave_time.leave_type.personal")
+          %th.hours.text-right= t("simple_form.options.leave_time.leave_type.sick")
+          %th.hours.text-right 總計
+      %tbody
+        - @users.each do |user|
+          %tr
+            %td.name=  user.name
+            %td= user.login_name
+            %td.hours.text-right= hours_to_humanize user.leave_applications.leave_hours_within_month(year: specific_year, month: specific_month, type: 'annual')
+            %td.hours.text-right= hours_to_humanize user.leave_applications.leave_hours_within_month(year: specific_year, month: specific_month, type: 'bonus')
+            %td.hours.text-right= hours_to_humanize user.leave_applications.leave_hours_within_month(year: specific_year, month: specific_month, type: 'personal')
+            %td.hours.text-right= hours_to_humanize user.leave_applications.leave_hours_within_month(year: specific_year, month: specific_month, type: 'sick')
+            %td.hours.text-right= hours_to_humanize user.leave_applications.leave_hours_within_month(year: specific_year, month: specific_month)
+- else
+  = no_data_alert

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -27,6 +27,8 @@
                 backend_leave_applications_path(status: :pending)
               %li= link_to t("title.backend/monthly_leave_times.index"),
                 backend_monthly_leave_times_path(year: specific_year, month: specific_month)
+              %li= link_to t("captions.backend/leave_applications.statistics"),
+                statistics_backend_leave_applications_path(year: specific_year, month: specific_month)
               %li= link_to t("title.backend/leave_times.index"),
                 backend_leave_times_path
 

--- a/config/locales/meta_data.zh_TW.yml
+++ b/config/locales/meta_data.zh_TW.yml
@@ -72,6 +72,7 @@ zh-TW:
       verify: "審核"
       approve: "核准"
       reject: "駁回"
+      statistics: "員工休假狀況"
     backend/monthly_leave_times:
       index: "員工休假狀況"
     backend/leave_times:
@@ -109,6 +110,7 @@ zh-TW:
     backend/leave_applications:
       index: "審核假單"
       verify: "審核假單"
+      statistics: "員工休假統計 v.2"
     backend/monthly_leave_times:
       index: "%{year} 年 %{month} 月 員工休假狀況"
     backend/leave_times:

--- a/config/locales/zh_TW.yml
+++ b/config/locales/zh_TW.yml
@@ -10,7 +10,7 @@ zh-TW:
     - 周五
     - 周六
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -36,7 +36,7 @@ zh-TW:
       long: "%Y年%b%d日"
       short: "%b%d日"
     month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -202,3 +202,4 @@ zh-TW:
       long: "%Y年%b%d日 %H:%M"
       short: "%b%d日 %H:%M"
     pm: 下午
+    humanize_working_hour: "%{days} 天 %{hours} 小時 (%{total}小時)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,8 @@ Rails.application.routes.draw do
       resources :users
 
       resources :leave_applications, only: [:index, :update] do
-        member do
-          get "verify"
-        end
+        get :verify, on: :member
+        get :statistics, on: :collection
       end
 
       resources :leave_times, only: [:index]

--- a/spec/controllers/backend/leave_applications_controller_spec.rb
+++ b/spec/controllers/backend/leave_applications_controller_spec.rb
@@ -1,4 +1,59 @@
 # frozen_string_literal: true
 require "rails_helper"
 RSpec.describe Backend::LeaveApplicationsController, type: :controller do
+  render_views
+
+  describe "statistics" do
+    let(:params) { { year: Time.current.year, month: Time.current.month } }
+    subject { get :statistics, params: params }
+
+    context "not logged in" do
+      include_examples "authorization failed"
+    end
+
+    context "logged in" do
+      context "as manager" do
+        login_manager
+
+        context "with records" do
+          let(:year)  { Time.current.year }
+          let(:month) { Time.current.month }
+          let(:start_time) { WorkingHours.advance_to_working_time(Time.new(year, month, 1) - 1.working.day) }
+          let(:end_time)   { WorkingHours.return_to_working_time(Time.new(year, month, 1) + 3.working.day) }
+          let(:params) { { year: year, month: month } }
+          let!(:leave_application) { FactoryGirl.create(:leave_application, :with_leave_time, :approved, :annual, start_time: start_time, end_time: end_time) }
+          let!(:leave_application2) { FactoryGirl.create(:leave_application, :with_leave_time, :approved, :personal, user: leave_application.user, start_time: start_time + 5.working.day, end_time: start_time + 7.working.day) }
+
+          context "approved" do
+            context "within given range" do
+              it "show records on page" do
+                expect(subject).to have_http_status :success
+                expect(assigns[:users]).to include leave_application.user
+                expect(assigns[:users].first.leave_applications).to include leave_application
+                expect(assigns[:users].first.leave_applications.leave_hours_within_month(year: year, month: month)).to eq 32
+                expect(assigns[:users].first.leave_applications.leave_hours_within_month(year: year, month: month, type: 'personal')).to eq 16
+                expect(response.body).not_to match "#{I18n.t("warnings.no_data")}"
+              end
+            end
+          end
+
+          context "not approved" do
+            let!(:leave_application) { FactoryGirl.create(:leave_application, :with_leave_time, :annual, start_time: start_time, end_time: end_time) }
+            let!(:leave_application2) { FactoryGirl.create(:leave_application, :with_leave_time, :personal, user: leave_application.user, start_time: start_time + 5.working.day, end_time: start_time + 7.working.day) }
+            it "should render no data alert" do
+              expect(subject).to have_http_status :success
+              expect(response.body).to match "#{I18n.t("warnings.no_data")}"
+            end
+          end
+        end
+
+        context "no leave_applications within month" do
+          it "should render no data alert" do
+            expect(subject).to have_http_status :success
+            expect(response.body).to match "#{I18n.t("warnings.no_data")}"
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/factories/leave_applicaiton.rb
+++ b/spec/factories/leave_applicaiton.rb
@@ -40,10 +40,20 @@ FactoryGirl.define do
 
     trait :with_leave_time do
       before(:create) do |la|
-        create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
+        if la.start_time.year == la.end_time.year
+          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
+        else
+          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
+          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.end_time.year)
+        end
       end
       after(:stub) do |la|
-        create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
+        if la.start_time.year == la.end_time.year
+          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
+        else
+          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
+          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.end_time.year)
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe ApplicationHelper do
+  describe "#hours_to_humanize" do
+    let(:params) { 0 }
+    subject { helper.hours_to_humanize(params) }
+
+    it "return `-` if 0 hours" do
+      expect(subject).to eq '-'
+    end
+
+    context "hours larger than 0" do
+      let(:params) { 10 }
+      it "return humanize working hours" do
+        expect(subject).to eq I18n.t("time.humanize_working_hour", days: 1, hours: 2, total: 10)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue #31, Add statistics for approved LeaveApplication by month
- Add Gem:
  - rails-controller-testing: inspect assigns and assert_template
    in test
  - rake-mini-profiler: database and view render efficiency profiling
- Add Backend/LeaveApplications#statistics
- Add scope :leave_within_range to fetch LeaveApplications overlaps
  with given range
- Add scope :with_leave_application_statistics to fetch approved
  LeaveApplication within given range & calculate them without N+1
- Add #hours_to_humanize helper method to tranlate working hours into
  haumanize results (x days x hours)