### PR TITLE
Issue #44, Ensure backend can only be accessed by HR, manager

### DIFF
--- a/app/controllers/backend/base_controller.rb
+++ b/app/controllers/backend/base_controller.rb
@@ -1,3 +1,12 @@
 # frozen_string_literal: true
 class Backend::BaseController < ::BaseController
+  before_action :authenticate_hr!
+
+  def authenticate_hr!
+    redirect_to root_path unless current_user.is_hr? || current_user.is_manager?
+  end
+
+  def authenticate_manager!
+    redirect_to root_path unless current_user.is_manager?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,12 @@ class User < ApplicationRecord
     .merge(LeaveTime.where(year: year)).distinct
   }
 
+  ROLES.each do |role|
+    define_method "is_#{role}?" do
+      self.role.to_sym == role
+    end
+  end
+
   def seniority(year = Time.now.year)
     if join_date.nil? or join_date.year > year
       0

--- a/spec/controllers/backend/leave_applications_controller_spec.rb
+++ b/spec/controllers/backend/leave_applications_controller_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Backend::LeaveApplicationsController, type: :controller do
     end
 
     context "logged in" do
+      context "as employee" do
+        login_employee
+        include_examples "authorization failed"
+      end
+
       context "as manager" do
         login_manager
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -160,4 +160,34 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "helper_method" do
+    describe "role identification" do
+      let(:employee) { FactoryGirl.create(:user, :employee) }
+      let(:manager)  { FactoryGirl.create(:user, :manager) }
+      let(:hr)  { FactoryGirl.create(:user, :hr) }
+
+      context "is_manager?" do
+        it "is true if user is manager" do
+          expect(manager.is_manager?).to be_truthy
+        end
+
+        it "is false if user is not manager" do
+          expect(hr.is_manager?).to be_falsey
+          expect(employee.is_manager?).to be_falsey
+        end
+      end
+
+      context "is_hr?" do
+        it "is true if user is hr" do
+          expect(hr.is_hr?).to be_truthy
+        end
+
+        it "is false if user is not hr" do
+          expect(employee.is_hr?).to be_falsey
+          expect(manager.is_hr?).to be_falsey
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
在 Backend::BaseController 中新增 `#authenticate_hr!` 方法，直接阻擋非 `manager`、`hr`  的使用者存取。