### PR TITLE
Issue #54, Alter LeaveTime structure to fit into new calculation rule

### DIFF
--- a/app/controllers/backend/users_controller.rb
+++ b/app/controllers/backend/users_controller.rb
@@ -3,7 +3,7 @@ class Backend::UsersController < Backend::BaseController
   before_action :set_minimum_password_length, only: [:new, :edit]
 
   def show
-    @leave_times = LeaveTime.current_year(params[:id])
+    @leave_times = LeaveTime.effective
   end
 
   def update

--- a/app/controllers/leave_times_controller.rb
+++ b/app/controllers/leave_times_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 class LeaveTimesController < BaseController
   def index
-    @current_collection = collection_scope.current_year(current_user.id, specific_year).page(params[:page])
+    # FIXME: This won't work since LeaveTime's structure has changed
+    @current_collection = collection_scope.overlaps(
+      Date.new(specific_year.to_i, 1, 1), Date.new(specific_year.to_i, 12, 1)
+    ).page(params[:page])
   end
 
   def show

--- a/app/models/leave_application.rb
+++ b/app/models/leave_application.rb
@@ -75,7 +75,7 @@ class LeaveApplication < ApplicationRecord
   end
 
   def leave_time
-    @leave_time ||= LeaveTime.personal(self.user_id, self.leave_type, self.start_time.year)
+    @leave_time ||= LeaveTime.personal(self.user_id, self.leave_type, self.start_time, self.end_time)
   end
 
   def range_exceeded?(beginning = WorkingHours.advance_to_working_time(1.month.ago.beginning_of_month), closing = WorkingHours.return_to_working_time(1.month.ago.end_of_month))
@@ -107,7 +107,6 @@ class LeaveApplication < ApplicationRecord
   def deduct_leave_time_usable_hours
     assign_hours
 
-    # leave_time = self.leave_time
     leave_time.deduct hours
     LeaveApplicationLog.create!(leave_application_uuid: uuid,
                                 amount: hours)
@@ -117,7 +116,6 @@ class LeaveApplication < ApplicationRecord
     assign_hours
     save!
 
-    leave_time = LeaveTime.personal(user_id, leave_type)
     log = leave_application_logs.last
     delta = log.returning? ? hours : (hours - log.amount)
 

--- a/app/models/leave_time.rb
+++ b/app/models/leave_time.rb
@@ -1,26 +1,36 @@
 # frozen_string_literal: true
 class LeaveTime < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: false
 
   BASIC_TYPES = %w(annual bonus personal sick).freeze
   MAX_ANNUAL_DAYS = Settings.leave_time.max_annual_days
-  DAILY_HOURS = Settings.leave_time.daily_hour 
+  DAILY_HOURS = Settings.leave_time.daily_hour
   DAYS_IN_YEAR = Settings.leave_time.days_in_a_year # ignore leap year
 
-  scope :current_year, ->(user_id, year=Time.now.year) {
-    where(year: year, user_id: user_id)
+  scope :personal, ->(user_id, leave_type, beginning, closing){
+    overlaps(beginning, closing).find_by(user_id: user_id, leave_type: leave_type)
   }
 
-  scope :personal, ->(user_id, leave_type, year = Time.current.year){
-    find_by(user_id: user_id, leave_type: leave_type, year: year)
-  }
-
-  scope :get_employees_bonus, ->(){
+  scope :get_employees_bonus, ->() {
     where("leave_type = ?", "bonus").order(user_id: :desc)
   }
 
-  validates :leave_type,
-            uniqueness: { scope: [:user_id, :year], message: '已存在該假別' }
+  scope :overlaps, ->(beginning, closing) {
+    where(
+      '(leave_times.effective_date, leave_times.expiration_date) OVERLAPS (timestamp :beginning, timestamp :closing)',
+      beginning: beginning, closing: closing
+    )
+  }
+
+  scope :effective, ->(date = Time.current) {
+    overlaps(date.beginning_of_day, date.end_of_day)
+  }
+
+  validates :leave_type,      presence: true
+  validates :effective_date,  presence: true
+  validates :expiration_date, presence: true
+  validate  :positive_range
+  validate  :range_not_overlaps
 
   def init_quota
     return false if seniority < 1
@@ -52,7 +62,7 @@ class LeaveTime < ApplicationRecord
     end
   end
 
-  ## Only calcualte when employees resign within a year 
+  ## Only calcualte when employees resign within a year
 
   def first_year_rate
     (days_by_leave_type * first_year_adjustment).round * DAILY_HOURS
@@ -92,12 +102,30 @@ class LeaveTime < ApplicationRecord
     base_day = 6.freeze
 
     case seniority
-    when 0 then 0 
+    when 0 then 0
     when 1 then 7
-    when 2 then 10 
+    when 2 then 10
     when (3..4) then 14
     when (5..9) then 15
     else seniority + base_day
     end
+  end
+
+  def overlaps?
+    LeaveTime.overlaps(effective_date, expiration_date)
+             .where(user_id: user_id, leave_type: leave_type)
+             .where.not(id: self.id).any?
+  end
+
+  def positive_range
+    unless self.expiration_date && self.effective_date && self.expiration_date >= self.effective_date
+      errors.add(:effective_date, :range_should_be_positive)
+    end
+  end
+
+  def range_not_overlaps
+     if self.expiration_date && self.effective_date && overlaps?
+       errors.add(:effective_date, :range_should_not_overlaps)
+     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,6 @@ class User < ApplicationRecord
       WorkingHours.return_to_working_time(Time.new(year, month, 1).end_of_month))
       .approved
     )
-    .merge(LeaveTime.where(year: year)).distinct
   }
 
   ROLES.each do |role|
@@ -48,7 +47,7 @@ class User < ApplicationRecord
 
   def seniority(time = Time.now)
     return 0 if join_date.nil?
-    
+
     seniority = ((time.to_date - join_date.to_date) / DAYS_IN_YEAR).to_i
     seniority == 0 ? seniority + 1 : seniority
   end

--- a/config/locales/meta_data.zh_TW.yml
+++ b/config/locales/meta_data.zh_TW.yml
@@ -42,6 +42,13 @@ zh-TW:
             end_time:
               not_integer: "請假的最小單位是1小時"
               not_enough_leave_time: "剩餘休假時間不足"
+        leave_time:
+          attributes:
+            user:
+              required: 休假時數必須屬於一個員工
+            effective_date:
+              range_should_be_positive: 截止日期應在生效日期之後
+              range_should_not_overlaps: 該類別休假額度已存在
 
   # navbar 選單標題
   nav:

--- a/db/migrate/20170105042400_add_valid_range_for_leave_time.rb
+++ b/db/migrate/20170105042400_add_valid_range_for_leave_time.rb
@@ -1,0 +1,28 @@
+class AddValidRangeForLeaveTime < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :leave_times, :year, :integer
+    add_column :leave_times, :effective_date,  :date
+    add_column :leave_times, :expiration_date, :date
+
+    LeaveTime.all.each do |leave_time|
+      leave_time.update(
+        effective_date:  Date.new(2016, 1,  1),
+        expiration_date: Date.new(2016, 12, 31)
+      )
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute 'alter table leave_times alter column effective_date  set default now()'
+        execute 'alter table leave_times alter column expiration_date set default now()'
+
+        change_column :leave_times, :effective_date,   :date, null: false
+        change_column :leave_times, :expiration_date,  :date, null: false
+        change_column :leave_times, :user_id, :integer, null: false
+      end
+      dir.down do
+        change_column :leave_times, :user_id, :integer, null: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161110095706) do
+ActiveRecord::Schema.define(version: 20170105042400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,16 +54,16 @@ ActiveRecord::Schema.define(version: 20161110095706) do
   end
 
   create_table "leave_times", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "year"
+    t.integer  "user_id",                                  null: false
     t.string   "leave_type"
-    t.integer  "quota",        default: 0
-    t.integer  "usable_hours", default: 0
-    t.integer  "used_hours",   default: 0
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.boolean  "refilled",     default: false
-    t.index ["year"], name: "index_leave_times_on_year", using: :btree
+    t.integer  "quota",           default: 0
+    t.integer  "usable_hours",    default: 0
+    t.integer  "used_hours",      default: 0
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+    t.boolean  "refilled",        default: false
+    t.date     "effective_date",  default: -> { "now()" }, null: false
+    t.date     "expiration_date", default: -> { "now()" }, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -3,7 +3,7 @@ namespace :dev do
   desc "Rebuild system"
   task rebuild: ["tmp:clear", "log:clear", "db:drop", "db:create", "db:migrate" ] do
     Rake::Task["import_data:users"].invoke
-    Rake::Task["leave_time:init"].invoke(Time.now.year, "force")
+    Rake::Task["leave_time:init"].invoke(2016, "force")
     Rake::Task["import_data:bonus_leave_times"].invoke
     Rake::Task["import_data:leaves"].invoke
     puts "rebuild success"

--- a/lib/tasks/import_data.rake
+++ b/lib/tasks/import_data.rake
@@ -59,7 +59,7 @@ namespace :import_data do
         quota: data[1],
         usable_hours: data[1]
       }
-      LeaveTime.personal(user_id, "bonus").update!(attributes)
+      LeaveTime.personal(user_id, "bonus", 2016).update!(attributes)
       puts "#{data[0]} 補修增加 #{data[1]} 時數"
     end
   end

--- a/spec/factories/leave_applicaiton.rb
+++ b/spec/factories/leave_applicaiton.rb
@@ -40,20 +40,14 @@ FactoryGirl.define do
 
     trait :with_leave_time do
       before(:create) do |la|
-        if la.start_time.year == la.end_time.year
-          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
-        else
-          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
-          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.end_time.year)
-        end
+        create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56,
+               effective_date:  la.start_time - 50.days,
+               expiration_date: la.start_time + 1.year )
       end
       after(:stub) do |la|
-        if la.start_time.year == la.end_time.year
-          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
-        else
-          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.start_time.year)
-          create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56, year: la.end_time.year)
-        end
+        create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56,
+               effective_date:  la.start_time - 50.days,
+               expiration_date: la.start_time + 1.year )
       end
     end
   end

--- a/spec/factories/leave_times.rb
+++ b/spec/factories/leave_times.rb
@@ -2,8 +2,9 @@
 FactoryGirl.define do
   factory :leave_time do
     user
-    year { Time.current.year }
     leave_type "annual"
+    effective_date  { Time.current.beginning_of_year }
+    expiration_date { Time.current.end_of_year }
 
     trait :annual do
       leave_type "annual"

--- a/spec/models/leave_time_spec.rb
+++ b/spec/models/leave_time_spec.rb
@@ -7,58 +7,237 @@ RSpec.describe LeaveTime, type: :model do
   let(:senior_employee) { FactoryGirl.create(:user, :employee, join_date: 30.years.ago) }
   let(:contractor)      { FactoryGirl.create(:user, :contractor) }
 
+  describe "#validations" do
+    subject { described_class.new(params) }
+
+    context "user" do
+      let(:params) { { user: nil } }
+      it "is invalid without user association" do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:user]).to include I18n.t("activerecord.errors.models.leave_time.attributes.user.required")
+      end
+    end
+
+    context "leave_type" do
+      let(:params) { { leave_type: nil } }
+      it "is invalid without :leave_type" do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:leave_type]).to include I18n.t("errors.messages.blank")
+      end
+    end
+
+    context "effective_date" do
+      let(:params) { { effective_date: nil } }
+      it "is invalid without :effective_date" do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:effective_date]).to include I18n.t("errors.messages.blank")
+      end
+    end
+
+    context "expiration_date" do
+      let(:params) { { expiration_date: nil } }
+      it "is invalid without :expiration_date" do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:expiration_date]).to include I18n.t("errors.messages.blank")
+      end
+    end
+
+    context "range" do
+      context "expiration_date earlier than effective_date" do
+        let(:params) {
+          FactoryGirl.attributes_for(:leave_time,
+            effective_date:  Time.current.strftime('%Y-%m-%d'),
+            expiration_date: (Time.current - 1.day).strftime('%Y-%m-%d')) }
+        it "is invalid" do
+          expect(subject.valid?).to be_falsey
+          expect(subject.errors.messages[:effective_date]). to include I18n.t("activerecord.errors.models.leave_time.attributes.effective_date.range_should_be_positive")
+        end
+      end
+
+      context "overlaps" do
+        let!(:leave_time) {
+          FactoryGirl.create(:leave_time, :annual,
+            effective_date:   Time.current.strftime('%Y-%m-%d'),
+            expiration_date: (Time.current + 3.day).strftime('%Y-%m-%d')) }
+
+        context "with owned records" do
+          context "same leave_type" do
+            let(:params) {
+              FactoryGirl.attributes_for(:leave_time, :annual,
+                effective_date:  (Time.current + 2.day).strftime('%Y-%m-%d'),
+                expiration_date: (Time.current + 4.day).strftime('%Y-%m-%d'),
+                user_id: leave_time.user_id) }
+            it "is invalid" do
+              expect(subject.valid?).to be_falsey
+              expect(subject.errors.messages[:effective_date]).to include I18n.t("activerecord.errors.models.leave_time.attributes.effective_date.range_should_not_overlaps")
+            end
+          end
+
+          context "different leave_type" do
+            let(:params) {
+              FactoryGirl.attributes_for(:leave_time, :personal,
+                effective_date:  (Time.current + 2.day).strftime('%Y-%m-%d'),
+                expiration_date: (Time.current + 4.day).strftime('%Y-%m-%d'),
+                user: leave_time.user) }
+            it "is valid" do
+              expect(subject.valid?).to be_falsey
+              expect(subject.errors.messages[:effective_date]).not_to include I18n.t("activerecord.errors.models.leave_time.attributes.effective_date.range_should_not_overlaps")
+            end
+          end
+        end
+
+        context "with others users' records" do
+          let(:params) {
+            FactoryGirl.attributes_for(:leave_time, :personal,
+              effective_date:  (Time.current + 2.day).strftime('%Y-%m-%d'),
+              expiration_date: (Time.current + 4.day).strftime('%Y-%m-%d')) }
+          it "is valid" do
+            expect(subject.valid?).to be_falsey
+            expect(subject.errors.messages[:effective_date]).not_to include I18n.t("activerecord.errors.models.leave_time.attributes.effective_date.range_should_not_overlaps")
+          end
+        end
+      end
+    end
+  end
+
+  describe ".scope" do
+    let(:beginning) { Time.current }
+    let(:ending)    { (Time.current + 1.year) }
+    let(:effective_date)  { beginning - 10.days }
+    let(:expiration_date) { beginning + 15.days }
+    let!(:leave_time) { FactoryGirl.create(:leave_time, :annual, effective_date: effective_date, expiration_date: expiration_date) }
+    describe ".overlaps" do
+      subject { described_class.overlaps(beginning, ending) }
+
+      context "partially overlaps" do
+        it "is include in returned results" do
+          expect(subject).to include leave_time
+        end
+      end
+
+      context "totally overlaps" do
+        let(:effective_date)  { beginning }
+        let(:expiration_date) { ending }
+        it "is include in returned results" do
+          expect(subject).to include leave_time
+        end
+      end
+
+      context "not overlaps at all" do
+        context "before given range" do
+          let(:effective_date)  { beginning - 10.days }
+          let(:expiration_date) { beginning - 5.days }
+          it "is not include in returned results" do
+            expect(subject).not_to include leave_time
+          end
+        end
+
+        context "after given range" do
+          let(:effective_date)  { ending + 5.days }
+          let(:expiration_date) { ending + 10.days }
+          it "is not include in returned results" do
+            expect(subject).not_to include leave_time
+          end
+        end
+      end
+    end
+
+    describe ".effective" do
+      context "no specific date given" do
+        subject { described_class.effective }
+
+        context "records overlaps with given date" do
+          let(:effective_date)  { Time.now - 3.days }
+          let(:expiration_date) { Time.now }
+          it "is include in returned results" do
+            expect(subject).to include leave_time
+          end
+        end
+
+        context "records not overlaps with give date" do
+          let(:effective_date)  { beginning - 3.days }
+          let(:expiration_date) { beginning - 1.days }
+          it "is not include in returned results" do
+            expect(subject).not_to include leave_time
+          end
+        end
+      end
+
+      context "a specific date given" do
+        let(:base_date) { (Time.current + 2.days) }
+        subject { described_class.effective(base_date) }
+
+        context "records overlaps with given date" do
+          let(:effective_date)  { base_date - 2.days }
+          let(:expiration_date) { base_date }
+          it "is include in returned results" do
+            expect(subject).to include leave_time
+          end
+        end
+
+        context "records not overlaps with given date" do
+          let(:effective_date)  { base_date + 1.days }
+          let(:expiration_date) { base_date + 2.days }
+          it "is not include in returned results" do
+            expect(subject).not_to include leave_time
+          end
+        end
+      end
+    end
+  end
+
   describe "init_quota" do
     context "annual leave" do
       it "first year employee should have 56 hours" do
         annual = FactoryGirl.create(:leave_time, :annual, user: first_year_employee)
         annual.init_quota
-        expect(annual.quota).to eq 56 
+        expect(annual.quota).to eq 56
       end
 
       it "third year employee should have 80 hours" do
         annual = FactoryGirl.create(:leave_time, :annual, user: third_year_employee)
         annual.init_quota
-        expect(annual.quota).to eq 80 
+        expect(annual.quota).to eq 80
       end
 
-      it "employee with 3-year employee tenure should have 112 hours" do 
+      it "employee with 3-year employee tenure should have 112 hours" do
         annual = FactoryGirl.create(:leave_time, :annual, user: FactoryGirl.build(:employee, join_date: 3.years.ago))
         annual.init_quota
-        expect(annual.quota).to eq 112 
+        expect(annual.quota).to eq 112
       end
 
-      it "employee with 4-year employee tenure should have 112 hours" do 
+      it "employee with 4-year employee tenure should have 112 hours" do
         annual = FactoryGirl.create(:leave_time, :annual, user: FactoryGirl.build(:employee, join_date: 4.years.ago))
         annual.init_quota
-        expect(annual.quota).to eq 112 
+        expect(annual.quota).to eq 112
       end
 
-      it "employee with 5-year employee tenure should have 120 hours" do 
+      it "employee with 5-year employee tenure should have 120 hours" do
         annual = FactoryGirl.create(:leave_time, :annual, user: FactoryGirl.build(:employee, join_date: 5.years.ago))
         annual.init_quota
         expect(annual.quota).to eq 120
       end
-      
-      it "employee with 9-year employee tenure should have 120 hours" do 
+
+      it "employee with 9-year employee tenure should have 120 hours" do
         annual = FactoryGirl.create(:leave_time, :annual, user: FactoryGirl.build(:employee, join_date: 9.years.ago))
         annual.init_quota
         expect(annual.quota).to eq 120
       end
 
-      context "employee with more than 10-year employee tenure should have extra 8 hours for each additional year" do 
-        it "employee with 10-year employee tenure should have 128 hours" do 
+      context "employee with more than 10-year employee tenure should have extra 8 hours for each additional year" do
+        it "employee with 10-year employee tenure should have 128 hours" do
           annual = FactoryGirl.create(:leave_time, :annual, user: FactoryGirl.build(:employee, join_date: 10.years.ago))
           annual.init_quota
           expect(annual.quota).to eq 128
         end
 
-        it "employee with 11-year employee tenure should have 136 hours" do 
+        it "employee with 11-year employee tenure should have 136 hours" do
           annual = FactoryGirl.create(:leave_time, :annual, user: FactoryGirl.build(:employee, join_date: 11.years.ago))
           annual.init_quota
           expect(annual.quota).to eq 136
         end
 
-        it "employee with 23-year employee tenure should have 232 hours" do 
+        it "employee with 23-year employee tenure should have 232 hours" do
           annual = FactoryGirl.create(:leave_time, :annual, user: FactoryGirl.build(:employee, join_date: 23.years.ago))
           annual.init_quota
           expect(annual.quota).to eq 232
@@ -101,7 +280,7 @@ RSpec.describe LeaveTime, type: :model do
       it "first year employee should have 56 hours (7 days)" do
         personal = FactoryGirl.create(:leave_time, :personal, user: first_year_employee)
         personal.init_quota
-        expect(personal.quota).to eq 56 
+        expect(personal.quota).to eq 56
       end
 
       it "regular employee should have 56 hours" do


### PR DESCRIPTION
- Remove column :year in LeaveTime, and add :effective_date,
  :expiration_date to calculate LeaveTime based on join_date
- Add NOT NULL constraint on table leave_times for column :user_id,
  :effective_date, :expiration_date
- Add presence validation for :user_id, :leave_type, :effective_date,
  :expiration_date on LeaveTime
- Add custom validation to check range and prevent records overlaps
  with owned records / in same leave_type
- Add scope :overlaps, :effective to fetch LeaveTime within specific
  range