### PR TITLE
issue #51 added legit leave types; some minor refactor

### DIFF
--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -9,11 +9,31 @@ defaults: &defaults
     role: 'admin'
     password: '12345678'
 
+  leave_types:
+    - annual
+    - bonus
+    - marriage
+    - funeral
+    - maternity
+    - personal
+    - official
+    - work_related_injury
+    - sick
+
   leave_time:
     leave_for_new_employees: true
     max_annual_days: 30
     daily_hour: 8
     days_in_a_year: 365.0
+
+  leaves:
+    marriage: 8
+    funeral: 365
+    maternity: 56
+    personal: 14
+    official: 365
+    work_related_injury: 365
+    sick: 30
 
 development:
   <<: *defaults

--- a/spec/factories/leave_times.rb
+++ b/spec/factories/leave_times.rb
@@ -6,20 +6,13 @@ FactoryGirl.define do
     effective_date  { Time.current.beginning_of_year }
     expiration_date { Time.current.end_of_year }
 
-    trait :annual do
-      leave_type "annual"
-    end
+    # leave_types include:
+    # "annual", "bonus", "marriage", "funeral", "maternity", "personal", "official", "work_related_injury", "sick"
 
-    trait :sick do
-      leave_type "sick"
-    end
-
-    trait :personal do
-      leave_type "personal"
-    end
-
-    trait :bonus do
-      leave_type "bonus"
+    Settings.leave_types.each do |type|
+      trait type.to_sym do
+        leave_type type
+      end
     end
   end
 end

--- a/spec/models/leave_time_spec.rb
+++ b/spec/models/leave_time_spec.rb
@@ -44,10 +44,11 @@ RSpec.describe LeaveTime, type: :model do
 
     context "range" do
       context "expiration_date earlier than effective_date" do
-        let(:params) {
+        let(:params) do
           FactoryGirl.attributes_for(:leave_time,
-            effective_date:  Time.current.strftime('%Y-%m-%d'),
-            expiration_date: (Time.current - 1.day).strftime('%Y-%m-%d')) }
+                                     effective_date:  Time.current.strftime("%Y-%m-%d"),
+                                     expiration_date:  1.day.ago .strftime("%Y-%m-%d"))
+        end
         it "is invalid" do
           expect(subject.valid?).to be_falsey
           expect(subject.errors.messages[:effective_date]). to include I18n.t("activerecord.errors.models.leave_time.attributes.effective_date.range_should_be_positive")
@@ -55,18 +56,20 @@ RSpec.describe LeaveTime, type: :model do
       end
 
       context "overlaps" do
-        let!(:leave_time) {
+        let!(:leave_time) do
           FactoryGirl.create(:leave_time, :annual,
-            effective_date:   Time.current.strftime('%Y-%m-%d'),
-            expiration_date: (Time.current + 3.day).strftime('%Y-%m-%d')) }
+                             effective_date:   Time.current.strftime("%Y-%m-%d"),
+                             expiration_date:  3.days.since .strftime("%Y-%m-%d"))
+        end
 
         context "with owned records" do
           context "same leave_type" do
-            let(:params) {
+            let(:params) do
               FactoryGirl.attributes_for(:leave_time, :annual,
-                effective_date:  (Time.current + 2.day).strftime('%Y-%m-%d'),
-                expiration_date: (Time.current + 4.day).strftime('%Y-%m-%d'),
-                user_id: leave_time.user_id) }
+                                         effective_date:   2.days.since .strftime("%Y-%m-%d"),
+                                         expiration_date:  4.days.since .strftime("%Y-%m-%d"),
+                                         user_id: leave_time.user_id)
+            end
             it "is invalid" do
               expect(subject.valid?).to be_falsey
               expect(subject.errors.messages[:effective_date]).to include I18n.t("activerecord.errors.models.leave_time.attributes.effective_date.range_should_not_overlaps")
@@ -74,11 +77,12 @@ RSpec.describe LeaveTime, type: :model do
           end
 
           context "different leave_type" do
-            let(:params) {
+            let(:params) do
               FactoryGirl.attributes_for(:leave_time, :personal,
-                effective_date:  (Time.current + 2.day).strftime('%Y-%m-%d'),
-                expiration_date: (Time.current + 4.day).strftime('%Y-%m-%d'),
-                user: leave_time.user) }
+                                         effective_date:   2.days.since .strftime("%Y-%m-%d"),
+                                         expiration_date:  4.days.since .strftime("%Y-%m-%d"),
+                                         user: leave_time.user)
+            end
             it "is valid" do
               expect(subject.valid?).to be_falsey
               expect(subject.errors.messages[:effective_date]).not_to include I18n.t("activerecord.errors.models.leave_time.attributes.effective_date.range_should_not_overlaps")
@@ -87,10 +91,11 @@ RSpec.describe LeaveTime, type: :model do
         end
 
         context "with others users' records" do
-          let(:params) {
+          let(:params) do
             FactoryGirl.attributes_for(:leave_time, :personal,
-              effective_date:  (Time.current + 2.day).strftime('%Y-%m-%d'),
-              expiration_date: (Time.current + 4.day).strftime('%Y-%m-%d')) }
+                                       effective_date:   2.days.since.strftime("%Y-%m-%d"),
+                                       expiration_date:  4.days.since.strftime("%Y-%m-%d"))
+          end
           it "is valid" do
             expect(subject.valid?).to be_falsey
             expect(subject.errors.messages[:effective_date]).not_to include I18n.t("activerecord.errors.models.leave_time.attributes.effective_date.range_should_not_overlaps")
@@ -102,7 +107,7 @@ RSpec.describe LeaveTime, type: :model do
 
   describe ".scope" do
     let(:beginning) { Time.current }
-    let(:ending)    { (Time.current + 1.year) }
+    let(:ending)    { 1.year.since }
     let(:effective_date)  { beginning - 10.days }
     let(:expiration_date) { beginning + 15.days }
     let!(:leave_time) { FactoryGirl.create(:leave_time, :annual, effective_date: effective_date, expiration_date: expiration_date) }
@@ -147,8 +152,8 @@ RSpec.describe LeaveTime, type: :model do
         subject { described_class.effective }
 
         context "records overlaps with given date" do
-          let(:effective_date)  { Time.now - 3.days }
-          let(:expiration_date) { Time.now }
+          let(:effective_date)  { 3.days.ago }
+          let(:expiration_date) { Time.current }
           it "is include in returned results" do
             expect(subject).to include leave_time
           end
@@ -156,7 +161,7 @@ RSpec.describe LeaveTime, type: :model do
 
         context "records not overlaps with give date" do
           let(:effective_date)  { beginning - 3.days }
-          let(:expiration_date) { beginning - 1.days }
+          let(:expiration_date) { beginning - 1.day }
           it "is not include in returned results" do
             expect(subject).not_to include leave_time
           end
@@ -164,7 +169,7 @@ RSpec.describe LeaveTime, type: :model do
       end
 
       context "a specific date given" do
-        let(:base_date) { (Time.current + 2.days) }
+        let(:base_date) { 2.days.since }
         subject { described_class.effective(base_date) }
 
         context "records overlaps with given date" do
@@ -176,7 +181,7 @@ RSpec.describe LeaveTime, type: :model do
         end
 
         context "records not overlaps with given date" do
-          let(:effective_date)  { base_date + 1.days }
+          let(:effective_date)  { base_date + 1.day }
           let(:expiration_date) { base_date + 2.days }
           it "is not include in returned results" do
             expect(subject).not_to include leave_time
@@ -187,7 +192,7 @@ RSpec.describe LeaveTime, type: :model do
   end
 
   describe "init_quota" do
-    shared_examples "annual_leave" do 
+    shared_examples "annual_leave" do
       it "third year employee should have 80 hours" do
         annual = FactoryGirl.create(:leave_time, :annual, user: third_year_employee)
         annual.init_quota
@@ -250,28 +255,35 @@ RSpec.describe LeaveTime, type: :model do
       end
     end
 
+    shared_examples "non-employees should have no leaves" do |leave_type|
+      it do
+        leave = FactoryGirl.build(:leave_time, leave_type, user: contractor)
+        expect(leave.init_quota).to be_falsy
+      end
+    end
+
     context "new employees have annual leave" do
       it_behaves_like "annual_leave"
       it "first year employee should have 56 hours" do
         annual = FactoryGirl.create(:leave_time, :annual, user: first_year_employee)
         annual.init_quota
-        expect(annual.quota).to eq 56 
+        expect(annual.quota).to eq 56
       end
     end
 
-    context "new employees have no annual leave" do 
+    context "new employees have no annual leave" do
       before { stub_const("LeaveTime::LEAVE_FOR_NEW_EMPLOYEES", false) }
       it_behaves_like "annual_leave"
       it "first year employee should have no annual leave" do
         annual = FactoryGirl.create(:leave_time, :annual, user: first_year_employee)
         annual.init_quota
-        expect(annual.quota).to eq 0 
+        expect(annual.quota).to eq 0
       end
     end
 
     context "sick leave" do
       it "first year employee should have 240 hours (30 days)" do
-        #FIXME: Test will failed when encountered leap year
+        # FIXME: Test will failed when encountered leap year
         sick = FactoryGirl.create(:leave_time, :sick, user: first_year_employee)
         sick.init_quota
         expect(sick.quota).to eq 240
@@ -283,29 +295,23 @@ RSpec.describe LeaveTime, type: :model do
         expect(sick.quota).to eq 240
       end
 
-      it "non-employee have no leave time" do
-        sick = FactoryGirl.create(:leave_time, :sick, user: contractor)
-        expect(sick.init_quota).to be_falsey
-      end
+      it_behaves_like "non-employees should have no leaves", :sick
     end
 
     context "personal leave" do
-      it "first year employee should have 56 hours (7 days)" do
+      it "first year employee should have 112 hours (14 days)" do
         personal = FactoryGirl.create(:leave_time, :personal, user: first_year_employee)
         personal.init_quota
-        expect(personal.quota).to eq 56
+        expect(personal.quota).to eq 112
       end
 
-      it "regular employee should have 56 hours" do
+      it "regular employee should have 112 hours" do
         personal = FactoryGirl.create(:leave_time, :personal, user: senior_employee)
         personal.init_quota
-        expect(personal.quota).to eq 56
+        expect(personal.quota).to eq 112
       end
 
-      it "non-employee have no leave time" do
-        personal = FactoryGirl.create(:leave_time, :personal, user: contractor)
-        expect(personal.init_quota).to be_falsey
-      end
+      it_behaves_like "non-employees should have no leaves", :personal
     end
 
     context "bonus leave" do
@@ -315,10 +321,57 @@ RSpec.describe LeaveTime, type: :model do
         expect(bonus.quota).to eq 0
       end
 
-      it "non-employee have no leave time" do
-        bonus = FactoryGirl.create(:leave_time, :bonus, user: contractor)
-        expect(bonus.init_quota).to be_falsey
+      it_behaves_like "non-employees should have no leaves", :bonus
+    end
+
+    context "marriage leave" do
+      it "employees should have 64 hours (8 days)" do
+        marriage = FactoryGirl.create(:leave_time, :marriage, user: first_year_employee)
+        marriage.init_quota
+        expect(marriage.quota).to eq 64
       end
+
+      it_behaves_like "non-employees should have no leaves", :marriage
+    end
+
+    context "funeral leave" do
+      it "employees should have 365 days" do
+        funeral = FactoryGirl.create(:leave_time, :funeral, user: first_year_employee)
+        funeral.init_quota
+        expect(funeral.quota).to eq 365 * 8
+      end
+
+      it_behaves_like "non-employees should have no leaves", :funeral
+    end
+
+    context "maternity leave" do
+      it "employees should have 56 days" do
+        maternity = FactoryGirl.create(:leave_time, :maternity, user: first_year_employee)
+        maternity.init_quota
+        expect(maternity.quota).to eq 56 * 8
+      end
+
+      it_behaves_like "non-employees should have no leaves", :maternity
+    end
+
+    context "official leave" do
+      it "employees should have 365 days" do
+        official = FactoryGirl.create(:leave_time, :official, user: first_year_employee)
+        official.init_quota
+        expect(official.quota).to eq 365 * 8
+      end
+
+      it_behaves_like "non-employees should have no leaves", :official
+    end
+
+    context "work related injury leave" do
+      it "employees should have 365 days" do
+        work_related_injury = FactoryGirl.create(:leave_time, :work_related_injury, user: first_year_employee)
+        work_related_injury.init_quota
+        expect(work_related_injury.quota).to eq 365 * 8
+      end
+
+      it_behaves_like "non-employees should have no leaves", :work_related_injury
     end
   end
 end


### PR DESCRIPTION
根據相關法規新增（修改）以下假別：
- 事假 (Personal) : 14 日 （原先設定 7 日）
- 婚假 (Marriage): 8 日
- 產假 (Maternity): 56 日
- 喪假 (Funeral): 365 日
- 公假 (Official): 365 日
- 公傷假 (Work-Related Injury): 365 日

其中喪假因為管管說以主管請示為主，因此直接給上限，請假的時候再由主管審核。公假及公傷假也是。產假有分安產跟小產，小產假是 28 日，建議是使用者請假的時候讓使用者可以選擇。