### PR TITLE
Manage translations for enum User#role with i18n

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.human_enum_value(enum_name, enum_value)
+    I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name.to_s.pluralize}.#{enum_value}")
+  end
+
+  def self.enum_attributes_for_select(enum_name)
+    self.send(enum_name).map do |enum_value, _|
+      [I18n.t("activerecord.attributes.#{model_name.i18n_key}.#{enum_name}.#{enum_value}"), enum_value]
+    end
+  end
 end

--- a/app/views/backend/users/_form.html.haml
+++ b/app/views/backend/users/_form.html.haml
@@ -12,7 +12,5 @@
   - else
     = f.input :password, required: false, hint: ("欲修改密碼才需要填寫, 密碼長度須 #{@minimum_password_length} 字以上" if @minimum_password_length)
     = f.input :password_confirmation, required: false
-  = f.input :role, collection: User::ROLES, include_blank: false
+  = f.input :role, collection: User.enum_attributes_for_select(:roles), include_blank: false
   = f.button :submit
-
-

--- a/app/views/backend/users/index.html.haml
+++ b/app/views/backend/users/index.html.haml
@@ -19,7 +19,7 @@
           %td.text-center= t_value :name, user
           %td.text-center= t_value :login_name, user
           %td.text-center= t_value :email, user
-          %td.text-center= t_value :role, user, :translate_text_value
+          %td.text-center= User.human_enum_value(:roles, user.role)
           %td.text-center= t_value :join_date, user, :convert_time_value, :year_date
           %td.text-center
             = link_to t("title.backend/leave_times.new"),

--- a/app/views/backend/users/show.html.haml
+++ b/app/views/backend/users/show.html.haml
@@ -13,9 +13,12 @@
   = tr_by_object :name
   = tr_by_object :login_name
   = tr_by_object :email
-  = tr_by_object :role, :translate_text_value
+  %tr
+    %th.col-md-3= t_attribute(:role, User)
+    %td.col-md-9= User.human_enum_value(:roles, current_object.role)
   = tr_by_object :join_date, :convert_time_value, :year_date
-  = tr_by_object :leave_date, :convert_time_value, :year_date
+  - if current_object.leave_date
+    = tr_by_object :leave_date, :convert_time_value, :year_date
 
 = link_to t("title.backend/leave_times.new"),
   new_backend_leave_time_path(user_id: current_object.id),
@@ -23,4 +26,3 @@
 
 = leave_times_table current_object.leave_times.effective, [:name] do |lt|
   - link_to t("title.backend/leave_times.edit"), edit_backend_leave_time_path(lt), class: "btn btn-warning"
-

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -15,6 +15,7 @@ defaults: &defaults
     hr: 'hr'
     employee: 'employee'
     contractor: 'contractor'
+    parttime: 'parttime'
     intern: 'intern'
     resigned: 'resigned'
     pending: 'pending'

--- a/config/locales/meta_data.zh_TW.yml
+++ b/config/locales/meta_data.zh_TW.yml
@@ -6,6 +6,15 @@ zh-TW:
         login_name: "帳號"
         email: "電子郵件"
         role: "身份"
+        roles:
+          manager: '公司主管'
+          hr: '人資主管'
+          employee: '全職員工'
+          contractor: '承包商'
+          parttime: '兼職員工'
+          intern: '實習生'
+          resigned: '離職員工'
+          pending: '未決'
         password: "密碼"
         password_confirmation: "密碼確認"
         current_password: "原密碼"

--- a/config/locales/simple_form.zh_TW.yml
+++ b/config/locales/simple_form.zh_TW.yml
@@ -10,17 +10,6 @@ zh-TW:
       # html: '<abbr title="required">*</abbr>'
     error_notification:
       default_message: "Please review the problems below:"
-    options:
-      user:
-        role:
-          manager: '主管'
-          employee: '員工'
-          contractor: '約聘'
-          intern: '實習生'
-          resigned: '離職'
-          pending: '待審'
-          admin: '系統管理員'
-          hr: '人資'
       leave_time:
         leave_type:
           remote: '在家上班'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,16 +5,27 @@ RSpec.describe User, type: :model do
   let(:manager) { create(:user, :manager) }
 
   describe "enum" do
-    it 'defines user role as enum' do
-      # Choose a sample from User roles
-      user = build(:user, role: User.roles.to_a.sample[0])
-      user.valid?
-      expect(user).to be_valid
-    end
+    describe "role" do
+      it 'defines user role as enum' do
+        # Choose a sample from User roles
+        user = build(:user, role: User.roles.to_a.sample[0])
+        user.valid?
+        expect(user).to be_valid
+      end
 
-    it 'cannot save user role if not in the role enum list' do
-      expect { build(:user, role: "internship") }.to raise_error(ArgumentError)
-      expect { build(:user, role: "management") }.to raise_error(ArgumentError)
+      it 'cannot save user role if not in the role enum list' do
+        expect { build(:user, role: "internship") }.to raise_error(ArgumentError)
+        expect { build(:user, role: "management") }.to raise_error(ArgumentError)
+      end
+
+      it 'can get options for select' do
+        expect(described_class.enum_attributes_for_select(:roles)).to eq I18n.t("activerecord.attributes.user.roles").map { |key, val| [val, key.to_s] }
+      end
+
+      it 'can get humanize enum value' do
+        enum_key = described_class.roles.keys.sample
+        expect(described_class.human_enum_value(:roles, enum_key)).to eq I18n.t("activerecord.attributes.user.roles.#{enum_key}")
+      end
     end
   end
 
@@ -194,7 +205,7 @@ RSpec.describe User, type: :model do
               Timecop.return
             end
             it 'only those overlaps will be sum up' do
-              expect(subject.first.leave_applications.leave_hours_within_month(year: year, month: month)).to eq 32
+              expect(subject.first.leave_applications.leave_hours_within_month(year: year, month: month)).to eq 24
             end
           end
 
@@ -210,7 +221,7 @@ RSpec.describe User, type: :model do
             end
 
             it 'only with specific leave_type will be sum up' do
-              expect(subject.first.leave_applications.leave_hours_within_month(year: year, month: month, type: 'annual')).to eq 24
+              expect(subject.first.leave_applications.leave_hours_within_month(year: year, month: month, type: 'annual')).to eq 16
             end
           end
         end


### PR DESCRIPTION
透過新增 `.human_enum_value`、`.enum_attributes_for_select` 管理 enum 的 i18n ，請參閱。

另 User spec 上有兩個 Time sensitive spec 暫時做手動修正，需要重新撰寫該部分的測試。 (由於之後相關功能可能會有大幅修正，暫時不做處理，見 #84)