### PR TITLE
Fix LeaveApplication auto calculated hours error

### DIFF
--- a/app/models/leave_application.rb
+++ b/app/models/leave_application.rb
@@ -110,7 +110,7 @@ class LeaveApplication < ApplicationRecord
 
   def auto_calculated_hours
     return 0 unless start_time && end_time
-    Biz.within(start_time, end_time).in_hours
+    $biz.within(start_time, end_time).in_hours
   end
 
   def hours_should_be_positive_integer

--- a/app/views/backend/users/show.html.haml
+++ b/app/views/backend/users/show.html.haml
@@ -24,5 +24,5 @@
   new_backend_leave_time_path(user_id: current_object.id),
   class: "btn btn-primary"
 
-= leave_times_table current_object.leave_times.effective, [:name] do |lt|
+= leave_times_table current_object.leave_times, [:name] do |lt|
   - link_to t("title.backend/leave_times.edit"), edit_backend_leave_time_path(lt), class: "btn btn-warning"

--- a/app/views/leave_applications/_form.html.haml
+++ b/app/views/leave_applications/_form.html.haml
@@ -7,7 +7,6 @@
     = f.input :leave_type, require: true, collection: LeaveApplication.enum_attributes_for_select(:leave_types)
   = f.input :start_time, date_time_picker_hash(:start, current_object[:start_time])
   = f.input :end_time, date_time_picker_hash(:end, current_object[:end_time])
-  = f.input :hours
   = f.input :description, required: true
   = f.button :submit, class: "submit"
 

--- a/config/initializers/biz.rb
+++ b/config/initializers/biz.rb
@@ -1,4 +1,4 @@
-Biz.configure do |config|
+$biz = Biz::Schedule.new do |config|
   config.hours = {
     mon: {'09:30' => '12:30', '13:30' => '18:30'},
     tue: {'09:30' => '12:30', '13:30' => '18:30'},


### PR DESCRIPTION
- Since `Biz` create [one schedule per thread](https://github.com/zendesk/biz/issues/18), global configuration might not work with Rails, assign Biz schedule as a global variable as a temporary fix for now.
- Remove unnecessary :hours field on LeaveApplication form.