### PR TITLE
#153 Fix LeaveApplication AASM and after_update callback

### DIFF
--- a/app/controllers/leave_applications_controller.rb
+++ b/app/controllers/leave_applications_controller.rb
@@ -51,7 +51,7 @@ class LeaveApplicationsController < BaseController
     if params[:id]
       current_user.leave_applications
     else
-      @q.result.order(id: :desc).page(params[:page])
+      @q.result.where(user_id: current_user.id).order(id: :desc).page(params[:page])
     end
   end
 

--- a/app/controllers/leave_applications_controller.rb
+++ b/app/controllers/leave_applications_controller.rb
@@ -25,14 +25,10 @@ class LeaveApplicationsController < BaseController
       current_object.assign_attributes(resource_params)
       if !current_object.changed?
         action_fail t('warnings.no_change'), :edit
+      elsif current_object.revise!
+        action_success
       else
-        current_object.revise(resource_params)
-        if current_object.errors[:hours].any?
-          @error_message = @current_object.errors[:hours]
-          render action: :edit
-        else
-          action_success
-        end
+        render action: :edit
       end
     end
   end

--- a/app/models/concerns/signature_concern.rb
+++ b/app/models/concerns/signature_concern.rb
@@ -8,7 +8,6 @@ module SignatureConcern
         manager_id: manager.id,
         sign_date: Time.current
       }
-      save!
     end
   end
 

--- a/app/models/leave_application.rb
+++ b/app/models/leave_application.rb
@@ -170,7 +170,7 @@ class LeaveApplication < ApplicationRecord
   end
 
   def update_leave_time_usages
-    return unless self.start_time_changed? or self.end_time_changed? or self.description_changed?
+    return if aasm.current_event != :revise
 
     case aasm.from_state
     when :pending then return_leave_time_usable_hours

--- a/app/models/leave_application.rb
+++ b/app/models/leave_application.rb
@@ -171,6 +171,7 @@ class LeaveApplication < ApplicationRecord
 
   def update_leave_time_usages
     return unless self.start_time_changed? or self.end_time_changed? or self.description_changed?
+
     case aasm.from_state
     when :pending then return_leave_time_usable_hours
     when :approved then return_approved_application_usable_hours

--- a/app/models/leave_application.rb
+++ b/app/models/leave_application.rb
@@ -34,7 +34,7 @@ class LeaveApplication < ApplicationRecord
     )
   }
 
-  scope :personal, ->(user_id, beginning, ending, status_array = ['pending', 'approved']) {
+  scope :personal, ->(user_id, beginning, ending, status_array = %w(pending approved)) {
     where(status: status_array, user_id: user_id).leave_within_range(beginning, ending)
   }
 
@@ -156,7 +156,7 @@ class LeaveApplication < ApplicationRecord
           leave_type: LeaveApplication.human_enum_value(:leave_type, la.leave_type),
           start_time: la.start_time.to_formatted_s(:month_date),
           end_time:   la.end_time.to_formatted_s(:month_date),
-          link:       url.leave_application_path({ id: la.id })
+          link:       url.leave_application_path(id: la.id)
         )
       )
     end

--- a/spec/factories/leave_applicaiton.rb
+++ b/spec/factories/leave_applicaiton.rb
@@ -28,8 +28,15 @@ FactoryGirl.define do
     end
 
     trait :approved do
-      status 'approved'
-      association :manager, factory: [:user, :manager]
+      before(:create) do |la|
+        create(:leave_time, la.leave_type.to_sym, user: la.user, quota: 56, usable_hours: 56,
+                                                  effective_date:  la.start_time - 50.days,
+                                                  expiration_date: la.start_time + 1.year)
+      end
+
+      after(:create) do |la|
+        la.reload.approve! create(:user, [:manager, :hr].sample)
+      end
     end
 
     trait :rejected do

--- a/spec/models/leave_application_spec.rb
+++ b/spec/models/leave_application_spec.rb
@@ -154,10 +154,6 @@ RSpec.describe LeaveApplication, type: :model do
       it { is_expected.to callback(:create_leave_time_usages).after(:create) }
     end
 
-    context 'should update LeaveTimeUsage after LeaveApplication updated' do
-      it { is_expected.to callback(:update_leave_time_usages).after(:update) }
-    end
-
     context '.create_leave_time_usages' do
       let(:total_leave_hours) { Daikichi::Config::Biz.within(start_time, end_time).in_hours }
 
@@ -189,7 +185,7 @@ RSpec.describe LeaveApplication, type: :model do
       shared_examples 'revise attribute' do |attribute, value|
         it "should successfully recreate LeaveTimeUsage when application #{attribute} changed" do
           leave_application.assign_attributes(attribute => value)
-          leave_application.revise(attribute => value)
+          leave_application.revise!
           leave_application.reload
           used_hours = Daikichi::Config::Biz.within(leave_application.start_time, leave_application.end_time).in_hours
           leave_time_usage = LeaveTimeUsage.where(leave_application: leave_application).first

--- a/spec/models/leave_application_spec.rb
+++ b/spec/models/leave_application_spec.rb
@@ -139,83 +139,189 @@ RSpec.describe LeaveApplication, type: :model do
     end    
   end
 
+  describe 'aasm' do
+    let(:manager) { create(:user, :manager) }
+    shared_examples 'transitions' do |params|
+      let(:leave_application) { create(:leave_application, params[:from]).reload }
+      describe 'without bang' do
+        it "transition from #{params[:from]} to #{params[:to]} with action #{params[:with_action]}" do
+          expect(leave_application.send(:"#{params[:from]}?")).to be_truthy
+          expect(leave_application.send(:"may_#{params[:with_action]}?")).to be_truthy
+          leave_application.send params[:with_action], (params[:manager_required] ? manager : nil)
+          expect(leave_application.send(:"#{params[:to]}?")).to be_truthy
+        end
+
+        it "should not update state when using AASM method #{params[:with_action]} without bang" do
+          leave_application.send params[:with_action], (params[:manager_required] ? manager : nil)
+          expect(leave_application.send :"#{params[:to]}?").to be_truthy
+          leave_application.reload
+          expect(leave_application.send :"#{params[:from]}?").to be_truthy
+        end
+      end
+
+      describe 'bang method' do
+        it "transition from #{params[:from]} to #{params[:to]} with action #{params[:with_action]}!" do
+          expect(leave_application.send(:"#{params[:from]}?")).to be_truthy
+          expect(leave_application.send(:"may_#{params[:with_action]}?")).to be_truthy
+          leave_application.send :"#{params[:with_action]}!", (params[:manager_required] ? manager : nil)
+          expect(leave_application.send(:"#{params[:to]}?")).to be_truthy
+        end
+
+        it "should update state when using AASM method #{params[:with_action]}" do
+          leave_application.send params[:with_action], (params[:manager_required] ? manager : nil)
+          expect(leave_application.send :"#{params[:to]}?").to be_truthy
+          leave_application.reload
+          expect(leave_application.send :"#{params[:from]}?").to be_truthy
+        end
+      end
+    end
+
+    it_should_behave_like 'transitions', from: :pending,  to: :approved, with_action: :approve, manager_required: true
+    it_should_behave_like 'transitions', from: :pending,  to: :canceled, with_action: :cancel
+    it_should_behave_like 'transitions', from: :pending,  to: :rejected, with_action: :reject,  manager_required: true
+    it_should_behave_like 'transitions', from: :pending,  to: :pending,  with_action: :revise
+    it_should_behave_like 'transitions', from: :approved, to: :pending,  with_action: :revise
+
+    describe 'conditional transition' do
+      let(:leave_application) { create(:leave_application, :happened) }
+      it 'can transition from approved to canceled unless LeaveApplication happened already' do
+        leave_application.reload.approve!(create(:user, :hr))
+        expect(leave_application.happened?).to be_truthy
+        expect(leave_application.approved?).to be_truthy
+        expect(leave_application.may_cancel?).to be_falsy
+      end
+    end
+  end
+
   describe 'callback' do
-    let(:user)            { create(:user) }
-    let(:quota)           { 100 }
-    let(:effective_date)  { Time.zone.local(2017, 5, 1) }
-    let(:expiration_date) { Time.zone.local(2017, 5, 30) }
-    let(:start_time)      { Time.zone.local(2017, 5, 1, 9, 30) }
-    let(:end_time)        { Time.zone.local(2017, 5, 5, 12, 30) }
+    let(:user)              { create(:user, :hr) }
+    let(:effective_date)    { Time.zone.local(2017, 5, 2) }
+    let(:expiration_date)   { Time.zone.local(2017, 5, 30) }
+    let(:start_time)        { Time.zone.local(2017, 5, 2, 9, 30) }
+    let(:end_time)          { Time.zone.local(2017, 5, 5, 10, 30) }
+    let(:total_leave_hours) { Daikichi::Config::Biz.within(start_time, end_time).in_hours }
+    let(:leave_application) { create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time) }
 
     before { User.skip_callback(:create, :after, :auto_assign_leave_time) }
     after  { User.set_callback(:create, :after, :auto_assign_leave_time)  }
 
-    context 'should create LeaveTimeUsage after LeaveApplication created' do
-      it { is_expected.to callback(:create_leave_time_usages).after(:create) }
-    end
+    describe '.create_leave_time_usages' do
+      let!(:leave_time)       { create(:leave_time, :annual, user: user, quota: total_leave_hours, usable_hours: total_leave_hours, effective_date: effective_date, expiration_date: expiration_date) }
+      context 'after_create' do 
+        it { is_expected.to callback(:create_leave_time_usages).after(:create) }
 
-    context '.create_leave_time_usages' do
-      let(:total_leave_hours) { Daikichi::Config::Biz.within(start_time, end_time).in_hours }
+        it 'should successfully create LeaveTimeUsage on sufficient LeaveTime hours' do
+          leave_time_usage = leave_application.leave_time_usages.first
+          leave_time.reload
+          expect(leave_time_usage.used_hours).to eq total_leave_hours
+          expect(leave_time_usage.leave_time).to eq leave_time
+          expect(leave_time.locked_hours).to eq total_leave_hours
+        end
 
-      it 'should successfully create LeaveTimeUsage on sufficient LeaveTime hours' do
-        # TODO: lt is a useless assignment
-        lt = create(:leave_time, :annual, user: user, quota: total_leave_hours, usable_hours: total_leave_hours, effective_date: effective_date, expiration_date: expiration_date)
-        la = create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time, description: 'Test string')
-        leave_time_usage = la.leave_time_usages.first
-        lt.reload
-        expect(leave_time_usage.used_hours).to eq total_leave_hours
-        expect(leave_time_usage.leave_time).to eq lt
-        expect(lt.usable_hours).to eq 0
-        expect(lt.used_hours).to eq 0
-        expect(lt.locked_hours).to eq total_leave_hours
-      end
-
-      it 'should not create LeaveTimeUsage when insufficient LeaveTime hours' do
-        lt = create(:leave_time, :annual, user: user, quota: total_leave_hours - 1, usable_hours: total_leave_hours - 1, effective_date: effective_date, expiration_date: expiration_date)
-        la = create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time)
-        lt.reload
-        expect(la.leave_time_usages.any?).to be false
-        expect(lt.usable_hours).to eq (total_leave_hours - 1)
-        expect(lt.used_hours).to eq 0
-        expect(lt.locked_hours).to eq 0
-      end
-    end
-
-    context '.update_leave_time_usages' do
-      shared_examples 'revise attribute' do |attribute, value|
-        it "should successfully recreate LeaveTimeUsage when application #{attribute} changed" do
-          leave_application.assign_attributes(attribute => value)
-          leave_application.revise!
-          leave_application.reload
-          used_hours = Daikichi::Config::Biz.within(leave_application.start_time, leave_application.end_time).in_hours
-          leave_time_usage = LeaveTimeUsage.where(leave_application: leave_application).first
-          leave_time = leave_time_usage.leave_time
-          expect(leave_application.hours).to eq used_hours
-          expect(leave_application.status).to eq "pending"
-          expect(leave_time_usage.used_hours).to eq used_hours
-          expect(leave_time.usable_hours).to eq quota - used_hours
-          expect(leave_time.used_hours).to eq 0
-          expect(leave_time.locked_hours).to eq used_hours
+        it 'should not create LeaveTimeUsage when insufficient LeaveTime hours' do
+          la = create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time + 1.hour)
+          expect(la.errors.any?).to be_truthy
+          expect(la.leave_time_usages.any?).to be false
+          expect(leave_time.usable_hours).to eq total_leave_hours
         end
       end
 
-      let!(:leave_time) { create(:leave_time, :annual, user: user, quota: quota, usable_hours: quota, effective_date: effective_date, expiration_date: expiration_date) }
-      context 'pending application' do
-        let!(:leave_application) { create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time) }
-        it_should_behave_like 'revise attribute', :start_time,  Time.zone.local(2017, 5, 3, 9, 30)
-        it_should_behave_like 'revise attribute', :end_time,    Time.zone.local(2017, 5, 3, 12, 30)
-        it_should_behave_like 'revise attribute', :description, Faker::Lorem.paragraph
-      end
+      context 'after_update' do
+        it { is_expected.to callback(:create_leave_time_usages).after(:update) }
+        it 'should recreate LeaveTimeUsage only when AASM event is "revise"' do
+          la = create(:leave_application, :annual, :approved, user: user, start_time: start_time, end_time: end_time)
+          leave_time_usage = la.leave_time_usages.first
+          leave_time.reload
+          expect(leave_time_usage.used_hours).to eq total_leave_hours
+          expect(leave_time_usage.leave_time).to eq leave_time
+          expect(leave_time.used_hours).to eq total_leave_hours
 
-      context 'approved application' do
-        let!(:leave_application) do 
-          create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time)
-          user.leave_applications.first.approve! user
-          user.leave_applications.first
+          la.assign_attributes(start_time: start_time + 1.hour)
+          la.revise!
+          leave_time_usage = la.leave_time_usages.first
+          leave_time.reload
+          expect(leave_time_usage.used_hours).to eq (total_leave_hours - 1)
+          expect(leave_time_usage.leave_time).to eq leave_time
+          expect(leave_time.locked_hours).to eq (total_leave_hours - 1)
         end
-        it_should_behave_like 'revise attribute', :start_time,  Time.zone.local(2017, 5, 3, 9, 30)
-        it_should_behave_like 'revise attribute', :end_time,    Time.zone.local(2017, 5, 3, 12, 30)
-        it_should_behave_like 'revise attribute', :description, Faker::Lorem.paragraph
+      end
+    end
+
+    describe '.hours_update' do
+      let(:quota) { 100 }
+      let!(:leave_time)       { create(:leave_time, :annual, user: user, quota: quota, usable_hours: quota, effective_date: effective_date, expiration_date: expiration_date) }
+      context 'before_update' do
+        it { is_expected.to callback(:hours_transfer).before(:update) }
+
+        describe 'AASM "approve" event' do
+          it 'should transfer locked_hours to used_hours' do
+            leave_time_usage = leave_application.leave_time_usages.first
+            leave_time.reload
+            expect(leave_time_usage.leave_time).to eq leave_time
+            expect(leave_time.usable_hours).to eq (quota - total_leave_hours)
+            expect(leave_time.locked_hours).to eq total_leave_hours
+            leave_application.reload.approve! user
+            leave_time.reload
+            expect(leave_time.usable_hours).to eq (quota - total_leave_hours)
+            expect(leave_time.used_hours).to eq total_leave_hours
+          end
+        end
+
+        shared_examples 'return locked_hours back to used_hours' do |event, required_user|
+          describe "AASM \"#{event}\" event" do
+            it "should return locked_hours back to used_hours when #{event}ed" do
+              leave_time_usage = leave_application.leave_time_usages.first
+              leave_time.reload
+              expect(leave_time_usage.leave_time).to eq leave_time
+              expect(leave_time.usable_hours).to eq (quota - total_leave_hours)
+              expect(leave_time.locked_hours).to eq total_leave_hours
+              leave_application.reload.send :"#{event}!", (required_user ? user : nil)
+              leave_time.reload
+              expect(leave_time.usable_hours).to eq quota
+              expect(leave_time.locked_hours).to be_zero
+            end
+          end
+        end
+
+        it_should_behave_like 'return locked_hours back to used_hours', :reject, true
+        it_should_behave_like 'return locked_hours back to used_hours', :cancel
+
+        describe 'AASM "revise" event' do
+          shared_examples 'revise attribute' do |attribute, value|
+            it "should successfully recreate LeaveTimeUsage when application #{attribute} changed" do
+              leave_application.assign_attributes(attribute => value)
+              leave_application.revise!
+              leave_application.reload
+              used_hours = Daikichi::Config::Biz.within(leave_application.start_time, leave_application.end_time).in_hours
+              leave_time_usage = leave_application.leave_time_usages.first
+              leave_time.reload
+              expect(leave_application.hours).to eq used_hours
+              expect(leave_application.status).to eq "pending"
+              expect(leave_time_usage.used_hours).to eq used_hours
+              expect(leave_time_usage.leave_time).to eq leave_time
+              expect(leave_time.usable_hours).to eq quota - used_hours
+              expect(leave_time.locked_hours).to eq used_hours
+            end
+          end
+
+          context 'pending application' do
+            let!(:leave_application) { create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time) }
+            it_should_behave_like 'revise attribute', :start_time,  Time.zone.local(2017, 5, 3, 9, 30)
+            it_should_behave_like 'revise attribute', :end_time,    Time.zone.local(2017, 5, 3, 12, 30)
+            it_should_behave_like 'revise attribute', :description, Faker::Lorem.paragraph
+          end
+
+          context 'approved application' do
+            let!(:leave_application) do 
+              create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time)
+              user.leave_applications.first.approve! user
+              user.leave_applications.first
+            end
+            it_should_behave_like 'revise attribute', :start_time,  Time.zone.local(2017, 5, 3, 9, 30)
+            it_should_behave_like 'revise attribute', :end_time,    Time.zone.local(2017, 5, 3, 12, 30)
+            it_should_behave_like 'revise attribute', :description, Faker::Lorem.paragraph
+          end
+        end
       end
     end
   end

--- a/spec/models/leave_application_spec.rb
+++ b/spec/models/leave_application_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe LeaveApplication, type: :model do
         end
       end
 
-      let!(:leave_time) { create(:leave_time, :annual, user: user, quota: quota, usable_hours: 100, effective_date: effective_date, expiration_date: expiration_date) }
+      let!(:leave_time) { create(:leave_time, :annual, user: user, quota: quota, usable_hours: quota, effective_date: effective_date, expiration_date: expiration_date) }
       context 'pending application' do
         let!(:leave_application) { create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time) }
         it_should_behave_like 'revise attribute', :start_time,  Time.zone.local(2017, 5, 3, 9, 30)

--- a/spec/models/leave_application_spec.rb
+++ b/spec/models/leave_application_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe LeaveApplication, type: :model do
             leave_type: described_class.human_enum_value(:leave_type, la.leave_type),
             start_time: la.start_time.to_formatted_s(:month_date),
             end_time:   la.end_time.to_formatted_s(:month_date),
-            link:       Rails.application.routes.url_helpers.leave_application_path({ id: la.id })
+            link:       Rails.application.routes.url_helpers.leave_application_path(id: la.id)
           )
         end
       end
@@ -122,7 +122,7 @@ RSpec.describe LeaveApplication, type: :model do
           expect(subject.valid?).to be_truthy
         end
       end
-      
+
       context 'overlaps only on other applications\' start_time' do
         let(:beginning) { start_time - 1.day }
         let(:ending)    { start_time }
@@ -136,7 +136,7 @@ RSpec.describe LeaveApplication, type: :model do
         it_should_behave_like 'valid', 'end_time', :pending
         it_should_behave_like 'valid', 'end_time', :approved
       end
-    end    
+    end
   end
 
   describe 'aasm' do
@@ -153,9 +153,9 @@ RSpec.describe LeaveApplication, type: :model do
 
         it "should not update state when using AASM method #{params[:with_action]} without bang" do
           leave_application.send params[:with_action], (params[:manager_required] ? manager : nil)
-          expect(leave_application.send :"#{params[:to]}?").to be_truthy
+          expect(leave_application.send(:"#{params[:to]}?")).to be_truthy
           leave_application.reload
-          expect(leave_application.send :"#{params[:from]}?").to be_truthy
+          expect(leave_application.send(:"#{params[:from]}?")).to be_truthy
         end
       end
 
@@ -169,9 +169,9 @@ RSpec.describe LeaveApplication, type: :model do
 
         it "should update state when using AASM method #{params[:with_action]}" do
           leave_application.send params[:with_action], (params[:manager_required] ? manager : nil)
-          expect(leave_application.send :"#{params[:to]}?").to be_truthy
+          expect(leave_application.send(:"#{params[:to]}?")).to be_truthy
           leave_application.reload
-          expect(leave_application.send :"#{params[:from]}?").to be_truthy
+          expect(leave_application.send(:"#{params[:from]}?")).to be_truthy
         end
       end
     end
@@ -206,8 +206,8 @@ RSpec.describe LeaveApplication, type: :model do
     after  { User.set_callback(:create, :after, :auto_assign_leave_time)  }
 
     describe '.create_leave_time_usages' do
-      let!(:leave_time)       { create(:leave_time, :annual, user: user, quota: total_leave_hours, usable_hours: total_leave_hours, effective_date: effective_date, expiration_date: expiration_date) }
-      context 'after_create' do 
+      let!(:leave_time) { create(:leave_time, :annual, user: user, quota: total_leave_hours, usable_hours: total_leave_hours, effective_date: effective_date, expiration_date: expiration_date) }
+      context 'after_create' do
         it { is_expected.to callback(:create_leave_time_usages).after(:create) }
 
         it 'should successfully create LeaveTimeUsage on sufficient LeaveTime hours' do
@@ -379,7 +379,7 @@ RSpec.describe LeaveApplication, type: :model do
               expect(subject).not_to include(leave_application)
             end
           end
-          
+
           context 'LeaveApplication end_time is at the start of the range' do
             let(:start_time) { closing }
             let(:end_time)   { closing + 5.days }
@@ -398,7 +398,7 @@ RSpec.describe LeaveApplication, type: :model do
             expect(subject).not_to include(leave_application)
           end
         end
-        
+
         context 'LeaveApplication end_time is at the start of the range' do
           let(:start_time) { closing }
           let(:end_time)   { closing + 5.days }
@@ -423,8 +423,8 @@ RSpec.describe LeaveApplication, type: :model do
       let!(:approved)       { create(:leave_application, :annual, :approved, user: user, start_time: Time.zone.local(2017, 5, 9, 9, 30), end_time: Time.zone.local(2017, 5, 11, 12, 30)) }
       let!(:canceled)       { create(:leave_application, :annual, :canceled, user: user, start_time: Time.zone.local(2017, 5, 16, 9, 30), end_time: Time.zone.local(2017, 5, 18, 12, 30)) }
       let!(:rejected)       { create(:leave_application, :annual, :rejected, user: user, start_time: Time.zone.local(2017, 5, 23, 9, 30), end_time: Time.zone.local(2017, 5, 25, 12, 30)) }
-        
-      after  { User.set_callback(:create, :after, :auto_assign_leave_time) }
+
+      after { User.set_callback(:create, :after, :auto_assign_leave_time) }
 
       context 'default behaviour' do
         it 'should include only pending or approved applications' do

--- a/spec/models/leave_application_spec.rb
+++ b/spec/models/leave_application_spec.rb
@@ -183,9 +183,15 @@ RSpec.describe LeaveApplication, type: :model do
     it_should_behave_like 'transitions', from: :approved, to: :pending,  with_action: :revise
 
     describe 'conditional transition' do
-      let(:leave_application) { create(:leave_application, :happened) }
+      let(:user)            { create(:user, :employee) }
+      let(:effective_date)  { Time.zone.local(2017, 6, 1).to_date  }
+      let(:expiration_date) { Time.zone.local(2017, 6, 30).to_date }
+      let(:start_time)      { Time.zone.local(2017, 6, 1, 9, 30)   }
+      let(:end_time)        { Time.zone.local(2017, 6, 5, 12, 30)  }
+      before { create(:leave_time, :annual, user: user, quota: 100, usable_hours: 100) }
       it 'can transition from approved to canceled unless LeaveApplication happened already' do
-        leave_application.reload.approve!(create(:user, :hr))
+        leave_application = create(:leave_application, :annual, user: user, start_time: start_time, end_time: end_time).reload
+        leave_application.approve!(create(:user, :hr))
         expect(leave_application.happened?).to be_truthy
         expect(leave_application.approved?).to be_truthy
         expect(leave_application.may_cancel?).to be_falsy


### PR DESCRIPTION
最主要會呼叫到 `after_update: :update_leave_time_usages` 的時機最主要是只有在 User 更改 start_time, end_time 或者是 description， **此PR避免如果只有 AASM 改變狀態的狀況下會再次觸發此回呼函式**