### PR TITLE
default leave_time effective for 'true' and issue #212

### DIFF
--- a/app/controllers/backend/leave_times_controller.rb
+++ b/app/controllers/backend/leave_times_controller.rb
@@ -37,7 +37,8 @@ class Backend::LeaveTimesController < Backend::BaseController
   end
 
   def search_params
-    params.fetch(:q, {})&.permit(:s, :leave_type_eq, :effective_true, :user_id_eq)
+    @search_params = params.fetch(:q, {})&.permit(:s, :leave_type_eq, :effective_true, :user_id_eq)
+    @search_params.present? ? @search_params : @search_params.merge(effective_true: true)
   end
 
   def url_after(action)

--- a/app/controllers/leave_times_controller.rb
+++ b/app/controllers/leave_times_controller.rb
@@ -28,6 +28,7 @@ class LeaveTimesController < BaseController
   end
 
   def search_params
-    params.fetch(:q, {})&.permit(:s, :leave_type_eq, :effective_true)
+    @search_params = params.fetch(:q, {})&.permit(:s, :leave_type_eq, :effective_true)
+    @search_params.present? ? @search_params : @search_params.merge(effective_true: true)
   end
 end

--- a/db/migrate/20170810032132_update_leave_application_leave_type.rb
+++ b/db/migrate/20170810032132_update_leave_application_leave_type.rb
@@ -1,0 +1,10 @@
+class UpdateLeaveApplicationLeaveType < ActiveRecord::Migration[5.0]
+  def self.up
+    LeaveApplication.where(leave_type: [:annual, :bonus]).each do |q|
+      q.update!(leave_type: :personal)
+    end
+  end
+
+  def self.down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170629025755) do
+ActiveRecord::Schema.define(version: 20170810032132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
1. 將預設查看請假額度調整為 '有效'
2. 修正 issue #212 因調整 leave_application 的 leave_type 而導致選擇 annual 或 bonus 的假單假別無法正確顯示問題。