### PR TITLE
fix ransack and arel relation

### DIFF
--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -4,6 +4,8 @@ document.addEventListener('turbolinks:load', function() {
 
     initDateTimePickers: function(elem) {
       $(elem).flatpickr({
+        defaultHour: 9,
+        defaultMinute: 30,
         enableTime: true,
         dateFormat: $(elem).data('format'),
         time_24hr: true,

--- a/app/controllers/backend/leave_times_controller.rb
+++ b/app/controllers/backend/leave_times_controller.rb
@@ -6,6 +6,16 @@ class Backend::LeaveTimesController < Backend::BaseController
     @users = User.all
   end
 
+  def new
+    @current_object = LeaveTime.ransack(@search_params).result.preload(:user).new
+  end
+
+  def create
+    @current_object = LeaveTime.ransack(@search_params).result.preload(:user).new(resource_params)
+    return render action: :new unless @current_object.save
+    action_success
+  end
+
   def append_quota
     @current_object = collection_scope.new(leave_time_params_by_leave_application)
     render :new

--- a/config/initializers/biz.rb
+++ b/config/initializers/biz.rb
@@ -61,6 +61,7 @@ module Daikichi
         Date.new(2017,  7, 22), # 週六休假
         Date.new(2017,  7, 29), # 週六休假
         Date.new(2017,  8,  5), # 週六休假
+        Date.new(2017,  8, 12), # 週六休假
         Date.new(2017,  8, 19), # 週六休假
         Date.new(2017,  8, 26), # 週六休假
         Date.new(2017,  9,  2), # 週六休假


### PR DESCRIPTION
1. 修改預設額度為有效（`@search_params.present? ? @search_params : @search_params.merge(effective_true: true)` ）後會導致 leave_time 的 new 無法正常運作，
所以修改 new 和 create method，覆蓋 base_controller 的 new 和 create method。

2. 修改 datetimepicker 預設值為 9:30

3. 修正 8/12 (六) 為放假日