### PR TITLE
Fix/fix leave time batch builder

### DIFF
--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -43,57 +43,48 @@ defaults: &defaults
       rejected: rejected
       canceled: canceled
     leave_types:
-      annual: annual
-      bonus: bonus
-      # unpaid: unpaid
       sick: sick
+      personal: personal
       official: official
       marriage: marriage
       compassionate: compassionate
-      personal: personal
+      maternity: maternity
       remote: remote
     available_quota_types:
-      annual:
-        - annual
-      bonus:
-        - bonus
-      unpaid:
-        - unpaid
       sick:
-        - sick # Deprecated
         - fullpaid_sick
         - halfpaid_sick
+      personal:
+        - bonus
+        - annual
+        - personal
       official:
         - official
       marriage:
         - marriage
       compassionate:
         - compassionate
-      # Deprecated
-      personal:
-        - bonus
-        - annual
-        - personal
+      maternity:
+        - maternity
       remote:
         - remote
 
   leave_times:
     quota_types:
-      annual: annual
       bonus: bonus
-      unpaid: unpaid
-      sick: sick # Deprecated
+      annual: annual
+      personal: personal #should be deprecated
       fullpaid_sick: fullpaid_sick
       halfpaid_sick: halfpaid_sick
+      remote: remote
       official: official
       marriage: marriage
       compassionate: compassionate
-      remote: remote
-      personal: personal #should be deprecated
+      maternity: maternity
 
   leed_days:
     monthly: 5 # working.days
-    join_date_based: 40 # days
+    join_date_based: 60 # days
 
   leave_types:
     annual:

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -131,7 +131,7 @@ defaults: &defaults
       quota: 23
     remote:
       creation: monthly
-      quota: 2 # days
+      quota: 4 # days
     marriage:
       creation: manually
       quota: 8 # days

--- a/lib/tasks/import_data.rake
+++ b/lib/tasks/import_data.rake
@@ -8,6 +8,7 @@ namespace :import_data do
       user.email = Settings.admin_user.email
       user.name = Settings.admin_user.name
       user.role = Settings.admin_user.role
+      user.join_date = Settings.admin_user.join_date
       user.password = Settings.admin_user.password
       user.password_confirmation = Settings.admin_user.password
     end

--- a/spec/services/leave_time_batch_builder_spec.rb
+++ b/spec/services/leave_time_batch_builder_spec.rb
@@ -66,9 +66,12 @@ describe LeaveTimeBatchBuilder do
 
       context 'not end of working month' do
         let(:join_date) { Date.current.end_of_month + 3.days - 2.years + join_date_based_leed_days.days }
-
         before do
-          Timecop.freeze(Date.current.end_of_month + 3.days)
+          if (Date.current.end_of_month + 3.days - 2.years).month && (Date.current.end_of_month + 3.days - 2.years).leap?
+            Timecop.freeze(Date.current.end_of_month + 2.days)
+          else
+            Timecop.freeze(Date.current.end_of_month + 3.days)
+          end
           described_class.new.automatically_import
         end
         after { Timecop.return }


### PR DESCRIPTION
#### app/services/leave_time_batch_builder.rb
本來是用月/日來比較是不是已經到了到職日的前60天
```
leed_day = Time.current + JOIN_DATE_BASED_LEED_DAYS.days  #就今天+60天
User.valid.where('(EXTRACT(MONTH FROM join_date), EXTRACT(DAY FROM join_date)) <= (:month, :date)', month: leed_day.month, date: leed_day.day)
```
但是像現在12/5號的話,60天後是2/3號, 現在的月/日反而比較大,這樣就會找不到東西
所以之前測試不會壞掉,到年底才壞掉
現在改成直接相減去看合不合條件
```
 user.this_year_join_anniversary - leed_day.to_date <= 60
```
#### spec/services/leave_time_batch_builder_spec.rb
最後一個測試會壞掉是因為,本來是像下面這樣這樣去確保測試在跑的時候今天一定是員工的到職週年
反正比方說2015年的5/8號的60天後和2019年的5/8號的60天後會是同一天
但是最近join_date生出來會是閏年的2月......
```
 let(:join_date) { Date.current.end_of_month + 3.days - 2.years + join_date_based_leed_days.days }
Timecop.freeze(Date.current.end_of_month + 3.days)
```
