### PR TITLE
修正新增員工產生休假時數相關問題

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,13 +98,13 @@ class User < ApplicationRecord
   end
 
   def parse_assign_leave_time_attr
-    return if !assign_leave_time? or self.assign_date.nil?
+    return if !assign_leave_time? or self.assign_date.blank?
     self.assign_date = Date.parse(self.assign_date)
   end
 
   def assign_leave_time_fields
     return unless assign_leave_time?
-    errors.add(:assign_date, :blank) if assign_date.nil?
+    errors.add(:assign_date, :blank) if assign_date.blank?
   end
 
   def auto_assign_leave_time

--- a/app/services/leave_time_builder.rb
+++ b/app/services/leave_time_builder.rb
@@ -70,6 +70,7 @@ class LeaveTimeBuilder
       date = expiration_date + 1.day
       expiration_date = date.next_year - 1.day
     end
+    create_leave_time(leave_type, quota, date, expiration_date) if Time.zone.now.to_date + JOIN_DATE_BASED_LEED_DAY >= date
   end
 
   def build_monthly_leave_types(leave_type, config, prebuild, build_by_assign_date = false)

--- a/app/services/leave_time_builder.rb
+++ b/app/services/leave_time_builder.rb
@@ -70,7 +70,6 @@ class LeaveTimeBuilder
       date = expiration_date + 1.day
       expiration_date = date.next_year - 1.day
     end
-    create_leave_time(leave_type, quota, date, expiration_date) if Time.zone.now.to_date + JOIN_DATE_BASED_LEED_DAY >= date or @user.join_date + 1.year >= Time.zone.now.to_date
   end
 
   def build_monthly_leave_types(leave_type, config, prebuild, build_by_assign_date = false)

--- a/spec/services/leave_time_builder_spec.rb
+++ b/spec/services/leave_time_builder_spec.rb
@@ -106,27 +106,38 @@ describe LeaveTimeBuilder do
         end
 
         context 'join date before current date within a year' do
-          let(:join_date) { current_date - 1.year }
+          let(:join_date) { current_date - 1.month }
+          let(:before_join_date) { join_date - 1.day }
+          let(:after_join_date_before_current_date) { join_date + 1.day }
+          before { user.join_date = join_date }
 
-          it 'should build LeaveTime based on assign_date when assign_date is after current date and after this year leed day' do
-            user.join_date = current_date + join_date_based_leed_day - 1.year
-            user.assign_date = (current_date + join_date_based_leed_day).to_s
+          it 'should build LeaveTime based on join_date when assign_date is before join_date without prebuild settings' do
+            user.assign_date = before_join_date.to_s
             user.save!
             join_date_based_leave_times(user) do |leave_times|
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/08/13'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/08/12'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/14'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
             end
           end
 
-          it 'should build LeaveTime based on assign_date when assign_date is after current date and before this year leed day' do
-            user.join_date = current_date + join_date_based_leed_day - 1.year + 1.day
-            user.assign_date = (current_date + join_date_based_leed_day + 1.day).to_s
+          it 'should build LeaveTime based on join_date when assign_date is on join_date without prebuild settings' do
+            user.assign_date = join_date.to_s
             user.save!
             join_date_based_leave_times(user) do |leave_times|
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/08/14'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/08/13'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/14'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
+            end
+          end
+
+          it 'should build LeaveTime based on assign_date when assign_date is after join_date and before current date without prebuild settings' do
+            user.assign_date = after_join_date_before_current_date.to_s
+            user.save!
+            join_date_based_leave_times(user) do |leave_times|
+              expect(leave_times.count).to eq 1
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/15'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
             end
           end
         end
@@ -305,11 +316,13 @@ describe LeaveTimeBuilder do
         end
 
         context 'join date before current date within a year' do
-          let(:join_date) { current_date - 1.year }
+          let(:join_date) { current_date - 1.month }
+          let(:before_join_date) { join_date - 1.day }
+          let(:after_join_date_before_current_date) { join_date + 1.day }
+          before { user.join_date = join_date }
 
-          it 'should build LeaveTime based on assign_date when assign_date is after current date and after this year leed day' do
-            user.join_date = current_date + join_date_based_leed_day - 1.year
-            user.assign_date = (current_date + join_date_based_leed_day).to_s
+          it 'should build LeaveTime based on join_date when assign_date is before join_date without prebuild settings' do
+            user.assign_date = before_join_date.to_s
             user.save!
             join_date_based_leave_times(user) do |leave_times, leave_type|
               if seniority_based_leave_types.map(&:first).include?(leave_type)
@@ -317,14 +330,13 @@ describe LeaveTimeBuilder do
                 next
               end
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/08/13'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/08/12'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/14'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
             end
           end
 
-          it 'should build LeaveTime based on assign_date when assign_date is after current date and before this year leed day' do
-            user.join_date = current_date + join_date_based_leed_day - 1.year + 1.day
-            user.assign_date = (current_date + join_date_based_leed_day + 1.day).to_s
+          it 'should build LeaveTime based on join_date when assign_date is on join_date without prebuild settings' do
+            user.assign_date = join_date.to_s
             user.save!
             join_date_based_leave_times(user) do |leave_times, leave_type|
               if seniority_based_leave_types.map(&:first).include?(leave_type)
@@ -332,8 +344,22 @@ describe LeaveTimeBuilder do
                 next
               end
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/08/14'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/08/13'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/14'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
+            end
+          end
+
+          it 'should build LeaveTime based on assign_date when assign_date is after join_date and before current date without prebuild settings' do
+            user.assign_date = after_join_date_before_current_date.to_s
+            user.save!
+            join_date_based_leave_times(user) do |leave_times, leave_type|
+              if seniority_based_leave_types.map(&:first).include?(leave_type)
+                expect(leave_times.any?).to be_falsey
+                next
+              end
+              expect(leave_times.count).to eq 1
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/15'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
             end
           end
         end

--- a/spec/services/leave_time_builder_spec.rb
+++ b/spec/services/leave_time_builder_spec.rb
@@ -32,10 +32,10 @@ describe LeaveTimeBuilder do
         end
 
         context 'join date before current date a year' do
-          let(:join_date) { current_date - 1.year - 1.month }
-          let(:before_join_date) { join_date - 1.month }
-          let(:after_join_date_before_current_date) { join_date + 1.month }
-          let(:after_current_date) { current_date + 1.month }
+          let(:join_date) { 13.months.ago }
+          let(:before_join_date) { 14.months.ago }
+          let(:after_join_date_before_current_date) { 12.months.ago }
+          let(:after_current_date) { 1.month.since }
           before { user.join_date = join_date }
 
           it 'should build LeaveTime based on join_date when assign_date is before join_date without prebuild settings' do
@@ -106,9 +106,9 @@ describe LeaveTimeBuilder do
         end
 
         context 'join date before current date within a year' do
-          let(:join_date) { current_date - 1.month }
-          let(:before_join_date) { join_date - 1.day }
-          let(:after_join_date_before_current_date) { join_date + 1.day }
+          let(:join_date) { 30.days.ago }
+          let(:before_join_date) { 31.days.ago }
+          let(:after_join_date_before_current_date) { 29.days.ago }
           before { user.join_date = join_date }
 
           it 'should build LeaveTime based on join_date when assign_date is before join_date without prebuild settings' do
@@ -116,8 +116,8 @@ describe LeaveTimeBuilder do
             user.save!
             join_date_based_leave_times(user) do |leave_times|
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/14'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/15'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/14'
             end
           end
 
@@ -126,8 +126,8 @@ describe LeaveTimeBuilder do
             user.save!
             join_date_based_leave_times(user) do |leave_times|
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/14'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/15'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/14'
             end
           end
 
@@ -136,8 +136,8 @@ describe LeaveTimeBuilder do
             user.save!
             join_date_based_leave_times(user) do |leave_times|
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/15'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/16'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/14'
             end
           end
         end
@@ -146,10 +146,10 @@ describe LeaveTimeBuilder do
       context 'import monthly LeaveTime with specific assign_date' do
         let(:user) { User.new(FactoryGirl.attributes_for(:user, :fulltime)) }
         let(:current_date) { Date.parse '2017/06/14' }
-        join_date = Date.parse('2017/06/14') - 1.year - 1.month
-        before_join_date = join_date - 1.month
-        after_join_date_before_current_date = join_date + 1.month
-        let(:after_current_date) { current_date + 1.month }
+        join_date = 13.months.ago
+        before_join_date = 14.months.ago
+        after_join_date_before_current_date = 12.months.ago
+        let(:after_current_date) { 1.month.since }
 
         before do
           Timecop.freeze current_date
@@ -218,10 +218,10 @@ describe LeaveTimeBuilder do
         end
 
         context 'join date before current date a year' do
-          let(:join_date) { current_date - 1.year - 1.month }
-          let(:before_join_date) { join_date - 1.month }
-          let(:after_join_date_before_current_date) { join_date + 1.month }
-          let(:after_current_date) { current_date + 1.month }
+          let(:join_date) { 13.months.ago }
+          let(:before_join_date) { 14.months.ago }
+          let(:after_join_date_before_current_date) { 12.months.ago }
+          let(:after_current_date) { 1.month.since }
           before { user.join_date = join_date }
 
           it 'should build LeaveTime based on join_date when assign_date is before join_date without prebuild settings' do
@@ -316,9 +316,9 @@ describe LeaveTimeBuilder do
         end
 
         context 'join date before current date within a year' do
-          let(:join_date) { current_date - 1.month }
-          let(:before_join_date) { join_date - 1.day }
-          let(:after_join_date_before_current_date) { join_date + 1.day }
+          let(:join_date) { 30.days.ago }
+          let(:before_join_date) { 31.days.ago }
+          let(:after_join_date_before_current_date) { 29.days.ago }
           before { user.join_date = join_date }
 
           it 'should build LeaveTime based on join_date when assign_date is before join_date without prebuild settings' do
@@ -330,8 +330,8 @@ describe LeaveTimeBuilder do
                 next
               end
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/14'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/15'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/14'
             end
           end
 
@@ -344,8 +344,8 @@ describe LeaveTimeBuilder do
                 next
               end
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/14'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/15'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/14'
             end
           end
 
@@ -358,8 +358,8 @@ describe LeaveTimeBuilder do
                 next
               end
               expect(leave_times.count).to eq 1
-              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/15'
-              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/13'
+              expect(leave_times.first.effective_date).to eq Date.parse '2017/05/16'
+              expect(leave_times.first.expiration_date).to eq Date.parse '2018/05/14'
             end
           end
         end
@@ -368,10 +368,10 @@ describe LeaveTimeBuilder do
       context 'import monthly LeaveTime with specific assign_date' do
         let(:user) { User.new(FactoryGirl.attributes_for(:user, :fulltime)) }
         let(:current_date) { Date.parse '2017/06/14' }
-        join_date = Date.parse('2017/06/14') - 1.year - 1.month
-        before_join_date = join_date - 1.month
-        after_join_date_before_current_date = join_date + 1.month
-        let(:after_current_date) { current_date + 1.month }
+        join_date = 13.months.ago
+        before_join_date = 14.months.ago
+        after_join_date_before_current_date = 12.months.ago
+        let(:after_current_date) { 1.month.since }
 
         before do
           Timecop.freeze current_date


### PR DESCRIPTION
- 目前在新增員工的時候，如果有勾選給予休假時數並且填入休假額度起始日期的話，如到職日為一年內人員系統會給予兩倍的時數( 當年度及下一年度休假 )，修正為到職日一年內人員只會產生當年度休假時數。

- 修正 如果新增員工時勾選了給予休假額度，但是沒有填寫起始日期、或是起始日期為零的話，系統直接拋出 Invalid Date 的 Exception 的 issue。