### PR TITLE
Update Capistrano from 3.8.0 to 3.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,8 +71,8 @@ group :development, :test do
 end
 
 group :development do
-  gem 'capistrano'
-  gem 'capistrano-rails'
+  gem 'capistrano', '~> 3.11.0'
+  gem 'capistrano-rails', '~> 1.4.0'
   gem 'capistrano-upload-config'
   gem 'capistrano-crono'
   gem 'listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,9 +427,9 @@ DEPENDENCIES
   bootstrap-sass
   byebug
   cancancan
-  capistrano
+  capistrano (~> 3.11.0)
   capistrano-crono
-  capistrano-rails
+  capistrano-rails (~> 1.4.0)
   capistrano-upload-config
   capybara
   carrierwave (~> 1.2, >= 1.2.3)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.8.1'
+lock '3.11.0'
 
 set :application, 'daikichi'
 set :repo_url, 'https://github.com/5xruby/daikichi'


### PR DESCRIPTION
因為之前的 PR Capistrano 升級了
把 Capistrano 的 lock 從 3.8.0 改成 3.11.0
