### PR TITLE
Update Capistrano default_env path

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -38,7 +38,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', '
 
 
 # Default value for default_env is {}
-set :default_env, { path: "$PATH:/usr/local/ruby23/bin:/usr/local/ruby-2.4.1/bin:" }
+set :default_env, { path: "$PATH:/usr/local/ruby26/bin" }
 
 # Default value for keep_releases is 5
 set :keep_releases, 3


### PR DESCRIPTION
正式站跟測試站用的 Ruby 版本升級了
所以更新使用 Ruby 的路徑