### PR TITLE
Only build special leave time for pending leave application

### DIFF
--- a/app/models/leave_time.rb
+++ b/app/models/leave_time.rb
@@ -148,7 +148,7 @@ class LeaveTime < ApplicationRecord
   def build_special_leave_time_usages
     return unless self.special_type?
 
-    leave_applications = User.find(self.user_id).leave_applications.where(leave_type: self.leave_type)
+    leave_applications = User.find(self.user_id).leave_applications.where(leave_type: self.leave_type).pending
     leave_applications.each do |la|
       if la.leave_time_usages.empty? and la.hours <= la.available_leave_times.pluck(:usable_hours).sum
         raise ActiveRecord::Rollback unless LeaveTimeUsageBuilder.new(la).build_leave_time_usages


### PR DESCRIPTION
目前生成公假或者類似的特殊額度會因為「檢查過往所有請假」而出現問題，暫時性修正方式為「只處理待審核狀態」的休假。